### PR TITLE
Feat/#18 : 공통 응답/예외 처리 로직 추가

### DIFF
--- a/src/main/java/site/walkies/walkie/global/web/dto/response/ExceptionResponse.java
+++ b/src/main/java/site/walkies/walkie/global/web/dto/response/ExceptionResponse.java
@@ -1,0 +1,11 @@
+package site.walkies.walkie.global.web.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExceptionResponse {
+    private int status;
+    private String message;
+}

--- a/src/main/java/site/walkies/walkie/global/web/dto/response/SuccessResponse.java
+++ b/src/main/java/site/walkies/walkie/global/web/dto/response/SuccessResponse.java
@@ -1,0 +1,56 @@
+package site.walkies.walkie.global.web.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SuccessResponse<D> {
+    private static final String DEFAULT_SUCCESS_MESSAGE = "요청을 성공했습니다.";
+    private static final String DEFAULT_CREATED_MESSAGE = "생성에 성공했습니다.";
+    private static final String DEFAULT_UPDATED_MESSAGE = "수정에 성공했습니다.";
+    private static final String DEFAULT_DELETED_MESSAGE = "삭제에 성공했습니다.";
+
+    private int status;
+    private String message;
+    private D data;
+
+    public static <D> SuccessResponse<D> ok(D data){
+        return new SuccessResponse<>(HttpStatus.OK, DEFAULT_SUCCESS_MESSAGE, data);
+    }
+
+    public static SuccessResponse<?> ok(){
+        return new SuccessResponse<>(HttpStatus.OK, DEFAULT_SUCCESS_MESSAGE);
+    }
+
+    public static <D> SuccessResponse<D> created(D data){
+        return new SuccessResponse<>(HttpStatus.CREATED, DEFAULT_CREATED_MESSAGE, data);
+    }
+
+    public static SuccessResponse<?> update(){
+        return new SuccessResponse<>(HttpStatus.OK, DEFAULT_UPDATED_MESSAGE);
+    }
+
+    public static SuccessResponse<?> deleted(){
+        return new SuccessResponse<>(HttpStatus.OK, DEFAULT_DELETED_MESSAGE);
+    }
+
+    @Builder
+    public SuccessResponse(HttpStatus status, String message, D data) {
+        this.status = status.value();
+        this.message = message;
+        this.data = data;
+    }
+
+    @Builder
+    public SuccessResponse(HttpStatus status, String message) {
+        this.status = status.value();
+        this.message = message;
+    }
+}

--- a/src/main/java/site/walkies/walkie/global/web/exception/CustomException.java
+++ b/src/main/java/site/walkies/walkie/global/web/exception/CustomException.java
@@ -1,0 +1,13 @@
+package site.walkies.walkie.global.web.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorcode;
+
+    public CustomException(ErrorCode errorcode) {
+        super(errorcode.getMessage());
+        this.errorcode = errorcode;
+    }
+}

--- a/src/main/java/site/walkies/walkie/global/web/exception/ErrorCode.java
+++ b/src/main/java/site/walkies/walkie/global/web/exception/ErrorCode.java
@@ -1,0 +1,35 @@
+package site.walkies.walkie.global.web.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    // 멤버 관련 예외
+    // 아래는 예시입니다. 오류 상황에 맞는 이름과 메시지를 만들고, 사용할 HttpStatus를 선택하면 됩니다.
+    //    USER_NOT_FOUND("존재하지 않는 유저입니다.", HttpStatus.UNAUTHORIZED),
+    //    USER_VALIDATION_ERROR("유저 검증 오류가 발생했습니다.", HttpStatus.UNAUTHORIZED),
+    //    INVALID_PASSWORD("올바르지 않은 비밀번호입니다.", HttpStatus.UNAUTHORIZED),
+    //    INVALID_ACCESS_TOKEN("올바르지 않은 ACCESSTOKEN 입니다", HttpStatus.UNAUTHORIZED),
+    //    JSON_PROCESSING_ERROR("JSON 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+
+    // 알 관련 예외
+
+    // 캐릭터 관련 예외
+
+    // 공지 관련 예외
+
+    // 리뷰 관련 예외
+
+    // 스팟 관련 예외
+    // 아래는 예시입니다. Enum이므로 마지막 예외에는 세미콜론 (;), 그 외에는 콤마(,)를 붙여줘야 합니다.
+    SPOT_NOT_FOUND("해당 id를 가진 스팟이 없습니다.", HttpStatus.NOT_FOUND);
+
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    ErrorCode(String message, HttpStatus httpStatus) {
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+}

--- a/src/main/java/site/walkies/walkie/global/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/walkies/walkie/global/web/exception/GlobalExceptionHandler.java
@@ -1,0 +1,38 @@
+package site.walkies.walkie.global.web.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import site.walkies.walkie.global.web.dto.response.ExceptionResponse;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    // @RestControllerAdvice와 @ExceptionHandler를 활용하여 컨트롤러 단에서 발생하는 예외를 중앙에서 처리
+
+    // CustomException에 대한 처리
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ExceptionResponse> handleCustomException(CustomException ex){
+        log.error("CustomException 발생: ", ex);
+        ExceptionResponse response = ExceptionResponse.builder()
+                .status(ex.getErrorcode().getHttpStatus().value())
+                .message(ex.getMessage())
+                .build();
+
+        return new ResponseEntity<>(response, ex.getErrorcode().getHttpStatus());
+    }
+
+    // 그 외의 모든 Exception에 대한 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> handleGeneralException(Exception ex){
+        log.error("Exception 발생: ", ex);
+        ExceptionResponse response = ExceptionResponse.builder()
+                .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .message("서버 내부 오류가 발생했습니다.")
+                .build();
+
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #18 

### 📝 작업 내용
- 공통 응답 처리 로직 추가
- 공통 예외 처리 로직 추가
    - 처음에는 Spring에서 제공하는 다양한 exception들을 묶어서 하나로 보내는 방식으로 사용해보려고 했는데, 실제로 프론트엔드에서 API 연결할 때 도움이 되려면 우리 상황에 맞는 CustomException을 만들어서 보내는 것이 좋을 거라고 생각해서 수정함.
    - 예외 처리 파일의 각 역할은 다음과 같습니다.
        - `ErrorCode.java` : CustomException을 모아놓는 Enum 입니다. 새로운 커스텀 예외를 만들 때 여기 가서 형식에 맞춰서 만들면 됩니다.
        - `CustomException.java` : 비즈니스 로직에서 에러가 발생할 경우, 해당 상황에 맞는 `ErrorCode` 를 인자로 받아 `CustomException`을 던집니다.
        -  `ExceptionResponse.java` : 예외 응답의 구조를 정의한 DTO  입니다.
        - `GlobalExceptionHandler.java` : 전역에서 발생하는 예외를 중앙집중적으로 처리하는 클래스입니다.
    - 에러 발생 시 전체적인 흐름은 [여기](https://sootudio-programming.tistory.com/entry/Spring-Boot%EC%9D%98-%EC%98%88%EC%99%B8-%EC%B2%98%EB%A6%AC-%EA%B3%B5%ED%86%B5-%EC%98%88%EC%99%B8-%EC%B2%98%EB%A6%AC-%EB%A1%9C%EC%A7%81-Custom-Exception-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0)에 적어 뒀습니다. ~~좋아요와 구독 부탁드려요~~
    - 사용 시에는 다음과 같이 사용할 수 있습니다.
        ```java
        if(user == null) {
            throw new CustomException(ErrorCode.USER_NOT_FOUND); // Errorcode.본인이_만든_예외_이름
        }
        ```

### 🙏🏻 리뷰 요청사항
- 예외 처리 방식이 기존에 설명했던 것과 바뀌었습니다. 사용 방법 자체는 크게 어렵지 않겠지만, 처리 로직 자체에 대한 추가적인 질문이 있다면 언제나 물어봐 주세요!!
