### PR TITLE
Feat/#60: 로그인 시 토큰 발급 코드 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,13 @@ dependencies {
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
-	//Webflux
+	// Webflux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'  // JSON 처리를 위한 부분
 }
 
 tasks.named('test') {

--- a/src/main/java/site/walkies/walkie/domain/auth/controller/AuthController.java
+++ b/src/main/java/site/walkies/walkie/domain/auth/controller/AuthController.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import site.walkies.walkie.domain.auth.service.AuthService;
 import site.walkies.walkie.domain.auth.service.dto.request.LoginRequestDto;
-import site.walkies.walkie.domain.member.service.dto.response.MemberResponseDto;
+import site.walkies.walkie.domain.auth.service.dto.response.LoginResponseDto;
 import site.walkies.walkie.global.web.dto.response.SuccessResponse;
 
 @Slf4j
@@ -17,12 +17,12 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public SuccessResponse<MemberResponseDto> login(@RequestBody LoginRequestDto requestDto) {
+    public SuccessResponse<LoginResponseDto> login(@RequestBody LoginRequestDto requestDto) {
         log.info("[AuthController] Received login request for provider: {}", requestDto.getProvider());
 
         // provider에 따라 로그인 처리
-        MemberResponseDto memberResponseDto = authService.login(requestDto);
+        LoginResponseDto loginResponseDto = authService.login(requestDto);
 
-        return SuccessResponse.ok(memberResponseDto);
+        return SuccessResponse.ok(loginResponseDto);
     }
 }

--- a/src/main/java/site/walkies/walkie/domain/auth/service/AuthService.java
+++ b/src/main/java/site/walkies/walkie/domain/auth/service/AuthService.java
@@ -4,8 +4,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import site.walkies.walkie.domain.auth.service.dto.request.LoginRequestDto;
 import site.walkies.walkie.domain.auth.service.dto.response.KakaoUserInfoResponseDto;
+import site.walkies.walkie.domain.auth.service.dto.response.LoginResponseDto;
 import site.walkies.walkie.domain.member.service.MemberLoginService;
 import site.walkies.walkie.domain.member.service.dto.response.MemberResponseDto;
+import site.walkies.walkie.global.auth.utils.JWTProvider;
 
 @Service
 @RequiredArgsConstructor
@@ -14,16 +16,33 @@ public class AuthService {
     private final KakaoService kakaoService;
     private final AppleService appleService;
     private final MemberLoginService memberLoginService;
+    private final JWTProvider jwtProvider;
 
-    public MemberResponseDto login(LoginRequestDto requestDto) {
+    public LoginResponseDto login(LoginRequestDto requestDto) {
+        MemberResponseDto memberResponseDto;
+
         switch (requestDto.getProvider().toLowerCase()) {
             case "kakao":
-                return loginWithKakao(requestDto.getAccessToken());
+                memberResponseDto = loginWithKakao(requestDto.getLoginAccessToken());
+                break;
             case "apple":
-                return loginWithApple(requestDto.getAccessToken());
+                memberResponseDto = loginWithApple(requestDto.getLoginAccessToken());
+                break;
             default:
                 throw new IllegalArgumentException("지원하지 않는 로그인 방식입니다.");
         }
+
+        // JWT 토큰 생성
+        String accessToken = jwtProvider.buildAccessToken(
+                memberResponseDto.getProviderId(),
+                memberResponseDto.getId()
+        );
+
+        return LoginResponseDto.builder()
+                .provider(memberResponseDto.getProvider())
+                .accessToken(accessToken)
+                .refreshToken(null) // Refresh Token은 추후 구현
+                .build();
     }
 
     private MemberResponseDto loginWithKakao(String accessToken) {

--- a/src/main/java/site/walkies/walkie/domain/auth/service/dto/request/LoginRequestDto.java
+++ b/src/main/java/site/walkies/walkie/domain/auth/service/dto/request/LoginRequestDto.java
@@ -7,6 +7,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class LoginRequestDto {
     private String provider;  // "kakao" 또는 "apple"
-    private String accessToken;  // 카카오 accessToken 또는 애플 idToken
+    private String loginAccessToken;  // 카카오 accessToken 또는 애플 idToken
 }
 

--- a/src/main/java/site/walkies/walkie/domain/auth/service/dto/response/LoginResponseDto.java
+++ b/src/main/java/site/walkies/walkie/domain/auth/service/dto/response/LoginResponseDto.java
@@ -1,0 +1,20 @@
+package site.walkies.walkie.domain.auth.service.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class LoginResponseDto {
+    private String provider;
+    private String accessToken;
+    private String refreshToken;
+
+    @Builder
+    public LoginResponseDto(String provider, String accessToken, String refreshToken) {
+        this.provider = provider;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
@@ -6,6 +6,8 @@ import site.walkies.walkie.domain.auth.service.dto.response.KakaoUserInfoRespons
 import site.walkies.walkie.domain.member.repository.MemberRepository;
 import site.walkies.walkie.domain.member.entity.Member;
 import site.walkies.walkie.domain.member.service.dto.response.MemberResponseDto;
+import site.walkies.walkie.global.web.exception.CustomException;
+import site.walkies.walkie.global.web.exception.ErrorCode;
 
 @Service
 @RequiredArgsConstructor
@@ -13,11 +15,13 @@ public class MemberLoginService {
 
     private final MemberRepository memberRepository;
 
+    // 카카오 로그인
     public MemberResponseDto findOrCreateKakaoMember(KakaoUserInfoResponseDto userInfo) {
         String providerId = userInfo.getId().toString();
         return findOrCreateMember("kakao", providerId, userInfo.getKakaoAccount().getProfile().getNickName());
     }
 
+    // 애플 로그인
     public MemberResponseDto findOrCreateAppleMember(String appleUserId) {
         return findOrCreateMember("apple", appleUserId, "애플 사용자");
     }
@@ -27,6 +31,12 @@ public class MemberLoginService {
         return memberRepository.findByProviderId(providerId)
                 .map(this::convertMemberToMemberResponseDto)
                 .orElseGet(() -> createMember(provider, providerId, nickname));
+    }
+
+    // memberId로 DB에서 정보 가져오기
+    public Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 
     // 멤버 생성

--- a/src/main/java/site/walkies/walkie/global/auth/dto/MemberPrincipal.java
+++ b/src/main/java/site/walkies/walkie/global/auth/dto/MemberPrincipal.java
@@ -1,0 +1,48 @@
+package site.walkies.walkie.global.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import site.walkies.walkie.domain.member.entity.Member;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public class MemberPrincipal implements UserDetails {
+
+    private Long memberId;
+    private String providerId;
+    private String provider;
+
+    public static MemberPrincipal createMemberAuthority(Member member){
+        return MemberPrincipal.builder()
+                .memberId(member.getId())
+                .providerId(member.getProviderId())
+                .provider(member.getProvider())
+                .build();
+    }
+
+    @Builder
+    private MemberPrincipal(Long memberId, String providerId, String provider) {
+        this.memberId = memberId;
+        this.providerId = providerId;
+        this.provider = provider;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getPassword() {
+        return null; // 소셜 로그인 방식이므로 비밀번호 사용 안 함
+    }
+
+    @Override
+    public String getUsername() {
+        return providerId; // 소셜 로그인이므로 고유한 식별자인 providerId 반환
+    }
+}

--- a/src/main/java/site/walkies/walkie/global/auth/exception/InvalidJWTException.java
+++ b/src/main/java/site/walkies/walkie/global/auth/exception/InvalidJWTException.java
@@ -1,0 +1,14 @@
+package site.walkies.walkie.global.auth.exception;
+
+public class InvalidJWTException extends RuntimeException {
+
+    public InvalidJWTException() {}
+
+    public InvalidJWTException(String message) {
+        super(message);
+    }
+
+    public InvalidJWTException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/site/walkies/walkie/global/auth/filter/JwtFilter.java
+++ b/src/main/java/site/walkies/walkie/global/auth/filter/JwtFilter.java
@@ -1,0 +1,84 @@
+package site.walkies.walkie.global.auth.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+import site.walkies.walkie.domain.member.entity.Member;
+import site.walkies.walkie.global.auth.dto.MemberPrincipal;
+import site.walkies.walkie.global.web.exception.CustomException;
+import site.walkies.walkie.global.web.exception.ErrorCode;
+
+import java.io.IOException;
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import site.walkies.walkie.domain.member.service.MemberLoginService;
+import site.walkies.walkie.global.auth.utils.JWTProvider;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtFilter extends GenericFilterBean {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private final JWTProvider jwtProvider;
+    private final MemberLoginService memberLoginService;
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        String requestURI = request.getRequestURI();
+
+        // JWT가 필요 없는 API 리스트 (로그인, 회원가입 등)
+        List<String> excludedUrls = List.of(
+                "/api/v1/auth/login"
+        );
+
+        // JWT 없이 접근 가능한 API는 필터를 건너뜀
+        if (excludedUrls.contains(requestURI)) {
+            log.info("[JwtFilter] '{}' 요청이므로 JWT 검증을 건너뜁니다.", requestURI);
+            filterChain.doFilter(request, servletResponse);
+            log.info("[JwtFilter] 필터를 통과한 후 요청이 정상적으로 전달되었습니다.");
+            return;
+        }
+
+        String jwt = resolveToken(request);
+
+        // ✅ JWT가 없으면 인증하지 않고 그냥 넘어가도록 변경
+        if (!StringUtils.hasText(jwt)) {
+            log.info("[JwtFilter] JWT 없음. 인증하지 않고 요청 진행.");
+            filterChain.doFilter(request, servletResponse);
+            return;
+        }
+
+        if (StringUtils.hasText(jwt) && jwtProvider.validateToken(jwt)) {
+            Long memberId = jwtProvider.getMemberId(jwt);
+            String providerId = jwtProvider.getProviderId(jwt);
+
+            Member member = memberLoginService.findMemberById(memberId);
+
+            UserDetails userDetails = MemberPrincipal.createMemberAuthority(member);
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } else {
+            throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN);
+        }
+        filterChain.doFilter(request, servletResponse);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/site/walkies/walkie/global/auth/utils/JWTProvider.java
+++ b/src/main/java/site/walkies/walkie/global/auth/utils/JWTProvider.java
@@ -1,0 +1,86 @@
+package site.walkies.walkie.global.auth.utils;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import site.walkies.walkie.global.auth.exception.InvalidJWTException;
+
+import javax.crypto.SecretKey;
+import java.time.Instant;
+import java.time.Clock;
+import java.util.Base64;
+import java.util.Date;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class JWTProvider implements InitializingBean {
+
+    private static final int ACCESS_TOKEN_EXPIRATION_PERIOD = 60 * 60 * 100;
+    private static final String PROVIDER_ID = "providerId";
+    private static final String MEMBER_ID = "memberId";
+
+    @Value("${jwt.key}")
+    private String encodedKeyValue;
+
+    private SecretKey key;
+    private final Clock clock;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        key = buildKey();
+    }
+
+    private SecretKey buildKey() {
+        byte[] decodedKeyValue = Base64.getDecoder().decode(encodedKeyValue);
+        return Keys.hmacShaKeyFor(decodedKeyValue);
+    }
+
+    public String buildAccessToken(String providerId, Long memberId) {
+        Instant now = clock.instant();
+
+        return Jwts.builder()
+                .claim(PROVIDER_ID, providerId)
+                .claim(MEMBER_ID, memberId)
+                .signWith(key)
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(now.plusSeconds(ACCESS_TOKEN_EXPIRATION_PERIOD)))
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        Jws<Claims> claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+        return !claims.getBody().getExpiration().before(new Date());
+    }
+
+    private Claims parsePayload(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .setClock(() -> Date.from(clock.instant()))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (JwtException exception) {
+            throw new InvalidJWTException("유효하지 않은 token 입니다.", exception);
+        }
+    }
+
+    public String getProviderId(String token) {
+        Claims payload = parsePayload(token);
+        return (String) payload.get(PROVIDER_ID);
+    }
+
+    public Long getMemberId(String token) {
+        Claims payload = parsePayload(token);
+        return ((Number) payload.get(MEMBER_ID)).longValue();
+    }
+}

--- a/src/main/java/site/walkies/walkie/global/config/SecurityConfig.java
+++ b/src/main/java/site/walkies/walkie/global/config/SecurityConfig.java
@@ -1,0 +1,39 @@
+package site.walkies.walkie.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import site.walkies.walkie.domain.member.service.MemberLoginService;
+import site.walkies.walkie.global.auth.filter.JwtFilter;
+import site.walkies.walkie.global.auth.utils.JWTProvider;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JWTProvider jwtProvider;
+    private final MemberLoginService memberLoginService;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorizeRequests -> authorizeRequests
+                        .requestMatchers("/auth/login").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(httpSecurityFormLoginConfigurer -> httpSecurityFormLoginConfigurer.disable()) // ✅ 로그인 폼 비활성화 (SNS 로그인만 사용)
+                .httpBasic(httpSecurityHttpBasicConfigurer -> httpSecurityHttpBasicConfigurer.disable()) // ✅ HTTP Basic 인증 비활성화
+                .addFilterBefore(new JwtFilter(jwtProvider, memberLoginService), UsernamePasswordAuthenticationFilter.class); // ✅ JwtFilter 직접 생성하여 추가
+
+        return http.build();
+    }
+}

--- a/src/main/java/site/walkies/walkie/global/config/TimeConfig.java
+++ b/src/main/java/site/walkies/walkie/global/config/TimeConfig.java
@@ -1,0 +1,21 @@
+package site.walkies.walkie.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+@Configuration
+public class TimeConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+
+    @Bean
+    public ZoneId zoneId() {
+        return ZoneId.of("Asia/Seoul");
+    }
+}

--- a/src/main/java/site/walkies/walkie/global/web/exception/ErrorCode.java
+++ b/src/main/java/site/walkies/walkie/global/web/exception/ErrorCode.java
@@ -10,7 +10,7 @@ public enum ErrorCode {
         USER_NOT_FOUND("존재하지 않는 유저입니다.", HttpStatus.UNAUTHORIZED),
     //    USER_VALIDATION_ERROR("유저 검증 오류가 발생했습니다.", HttpStatus.UNAUTHORIZED),
     //    INVALID_PASSWORD("올바르지 않은 비밀번호입니다.", HttpStatus.UNAUTHORIZED),
-    //    INVALID_ACCESS_TOKEN("올바르지 않은 ACCESSTOKEN 입니다", HttpStatus.UNAUTHORIZED),
+        INVALID_ACCESS_TOKEN("올바르지 않은 ACCESSTOKEN 입니다", HttpStatus.UNAUTHORIZED),
     //    JSON_PROCESSING_ERROR("JSON 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // 알 관련 예외

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,3 +17,6 @@ spring.web.resources.static-locations=classpath:/static/,file:files/
 ## kakao authentication
 kakao.client_id=${REST_API_KEY}
 kakao.redirect_uri=http://localhost:8080/api/v1/callback
+
+## JWT
+jwt.key=${JWT_KEY}


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #60 

### 📝 작업 내용
- 이제 로그인 시, 회원정보 저장과 함께 AccessToken도 보냅니다.
- RefeshToken은 아직 구현하지 않고, AccessToken의 시간을 100시간으로 만들어 놨습니다.
![image](https://github.com/user-attachments/assets/05ed0c14-c797-49c7-af3f-bae7988c33cb)
![image](https://github.com/user-attachments/assets/ff8564cd-30b9-4be9-b426-eaeed2ef069f)
![image](https://github.com/user-attachments/assets/5207f2a1-e1ba-4512-a945-6f588a4843b3)



### 🙏 리뷰 요구사항
- 
