### PR TITLE
Feat/#73 : 멤버 정보 수정 API 개발

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/member/controller/MemberController.java
+++ b/src/main/java/site/walkies/walkie/domain/member/controller/MemberController.java
@@ -2,10 +2,9 @@ package site.walkies.walkie.domain.member.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import site.walkies.walkie.domain.member.service.MemberService;
+import site.walkies.walkie.domain.member.service.dto.request.MemberUpdateRequestDto;
 import site.walkies.walkie.domain.member.service.dto.response.MemberResponseDto;
 import site.walkies.walkie.global.auth.dto.MemberPrincipal;
 import site.walkies.walkie.global.web.dto.response.SuccessResponse;
@@ -22,5 +21,12 @@ public class MemberController {
     public SuccessResponse<MemberResponseDto> getMemberInfo(@AuthenticationPrincipal MemberPrincipal memberPrincipal ) {
         MemberResponseDto memberResponseDto = memberService.getMemberInfo(memberPrincipal.getMemberId());
         return SuccessResponse.ok(memberResponseDto);
+    }
+
+    // 사용자 정보 수정
+    @PatchMapping
+    public SuccessResponse<MemberResponseDto> updateMemberInfo(@AuthenticationPrincipal MemberPrincipal memberPrincipal, @RequestBody MemberUpdateRequestDto memberUpdateRequestDto ) {
+        MemberResponseDto memberResponseDto = memberService.updateMemberInfo(memberPrincipal.getMemberId(), memberUpdateRequestDto);
+        return SuccessResponse.updated(memberResponseDto);
     }
 }

--- a/src/main/java/site/walkies/walkie/domain/member/entity/Member.java
+++ b/src/main/java/site/walkies/walkie/domain/member/entity/Member.java
@@ -60,4 +60,8 @@ public class Member {
         this.levelingEgg = levelingEgg;
         this.levelingUserCharacter = levelingUserCharacter;
     }
+
+    public void changeNickname(String newNickname) {
+        this.nickname = newNickname;
+    }
 }

--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
@@ -2,8 +2,10 @@ package site.walkies.walkie.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import site.walkies.walkie.domain.member.entity.Member;
 import site.walkies.walkie.domain.member.repository.MemberRepository;
+import site.walkies.walkie.domain.member.service.dto.request.MemberUpdateRequestDto;
 import site.walkies.walkie.domain.member.service.dto.response.MemberResponseDto;
 import site.walkies.walkie.global.web.exception.CustomException;
 import site.walkies.walkie.global.web.exception.ErrorCode;
@@ -14,17 +16,32 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     // 사용자 정보 조회
+    @Transactional(readOnly = true)
     public MemberResponseDto getMemberInfo(Long memberId){
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return convertMemberToResponseDto(member);
+    }
 
+    // 사용자 정보 업데이트
+    @Transactional
+    public MemberResponseDto updateMemberInfo(Long memberId, MemberUpdateRequestDto memberUpdateRequestDto){
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if(memberUpdateRequestDto.getMemberNickname() != null){
+            member.changeNickname(memberUpdateRequestDto.getMemberNickname());
+        }
+        return convertMemberToResponseDto(member);
+    }
+
+    // Member객체를 MemberResponse DTO로 변경
+    public MemberResponseDto convertMemberToResponseDto(Member member){
         return MemberResponseDto.builder()
                 .id(member.getId())
                 .provider(member.getProvider())
                 .nickname(member.getNickname())
                 .isPublic(member.getIsPublic())
                 .memberTier(member.getMemberTier())
-                .eggId(member.getLevelingEgg().getId())
-                .userCharacterId(member.getLevelingUserCharacter().getId())
+                .eggId(member.getLevelingEgg() != null ? member.getLevelingEgg().getId() : null)
+                .userCharacterId(member.getLevelingUserCharacter() != null ? member.getLevelingUserCharacter().getId() : null)
                 .recordedSpot(member.getRecordedSpot())
                 .exploredSpot(member.getExploredSpot())
                 .build();

--- a/src/main/java/site/walkies/walkie/domain/member/service/dto/request/MemberUpdateRequestDto.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/dto/request/MemberUpdateRequestDto.java
@@ -1,0 +1,16 @@
+package site.walkies.walkie.domain.member.service.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberUpdateRequestDto {
+    private String memberNickname;
+
+    @Builder
+    public MemberUpdateRequestDto(String memberNickname) {
+        this.memberNickname = memberNickname;
+    }
+}


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #73 

### 📝 작업 내용
- 멤버 정보 수정 API 개발
- 까먹고 있었는데, 서비스 메서드에 `@Transactional` 을 붙히면 Entity 수정 후 저장이 자동으로 된다고 합니다. 분명히 토프링 스터디에서 배웠던 것 같은데...

### 🙏 리뷰 요구사항
- 현재는 닉네임만 변경 가능합니다 ^^;
