### PR TITLE
Fix/#87 : 멤버가 부화시키는 알 변경 시 알 picked 필드도 함께 변경되도록 수정

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/egg/entity/Egg.java
+++ b/src/main/java/site/walkies/walkie/domain/egg/entity/Egg.java
@@ -64,4 +64,9 @@ public class Egg {
         this.nowStep = nowStep;
         return this;
     }
+
+    public Egg changePicked(Boolean picked) {
+        this.picked = picked;
+        return this;
+    }
 }

--- a/src/main/java/site/walkies/walkie/domain/member/controller/MemberController.java
+++ b/src/main/java/site/walkies/walkie/domain/member/controller/MemberController.java
@@ -31,7 +31,7 @@ public class MemberController {
         return SuccessResponse.updated(memberResponseDto);
     }
 
-    // 사용자가 레벨업 시키는 알 변경
+    // 사용자가 부화 시키는 알 변경
     @PatchMapping("/eggs/play")
     public SuccessResponse<MemberResponseDto> updateMemberLevelingEgg(@AuthenticationPrincipal MemberPrincipal memberPrincipal, @RequestBody MemberUpdateLevelingEggRequestDto memberUpdateLevelingEggRequestDto){
         MemberResponseDto memberResponseDto = memberService.updateMemberLevelingEgg(memberPrincipal.getMemberId(), memberUpdateLevelingEggRequestDto);

--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
@@ -36,15 +36,18 @@ public class MemberService {
         return convertMemberToResponseDto(member);
     }
 
-    // 사용자와 함께 걷는 알 변경
+    // 사용자가 부화시키는 알 변경
     @Transactional
     public MemberResponseDto updateMemberLevelingEgg(Long memberId, MemberUpdateLevelingEggRequestDto memberUpdateLevelingEggRequestDto){
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Egg previousEgg = member.getLevelingEgg();
+        previousEgg.changePicked(false);
 
         Egg egg = eggRepository.findById(memberUpdateLevelingEggRequestDto.getEggId())
                 .orElseThrow(() -> new CustomException(ErrorCode.EGG_NOT_FOUND));
 
-        member.changeLevelingEgg(egg); // 또는 changeLevelingEgg(egg);
+        member.changeLevelingEgg(egg);
+        egg.changePicked(true);
 
         return convertMemberToResponseDto(member);
     }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #87 

### 📝 작업 내용
- memberService에서 알의 상태도 함께 변경하도록 코드 추가
- 이전 알은 false, 새로운 알은 true
![image](https://github.com/user-attachments/assets/3fedf170-65c8-4a05-85e4-8676bf9a0699)

### 🙏 리뷰 요구사항
- 리뷰 제대로 확인 안하고 머지해서 미안합니다 ㅠㅠ
