### PR TITLE
Feat/#85 : 멤버 프로필 공개 여부 토글 기능

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/member/controller/MemberController.java
+++ b/src/main/java/site/walkies/walkie/domain/member/controller/MemberController.java
@@ -37,4 +37,11 @@ public class MemberController {
         MemberResponseDto memberResponseDto = memberService.updateMemberLevelingEgg(memberPrincipal.getMemberId(), memberUpdateLevelingEggRequestDto);
         return SuccessResponse.updated(memberResponseDto);
     }
+
+    // 사용자 프로필 조회 토글
+    @PatchMapping("/profile/visibility")
+    public SuccessResponse<MemberResponseDto> toggleMemberProfileVisibility(@AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+        MemberResponseDto memberResponseDto = memberService.toggleMemberProfileVisibility(memberPrincipal.getMemberId());
+        return SuccessResponse.updated(memberResponseDto);
+    }
 }

--- a/src/main/java/site/walkies/walkie/domain/member/entity/Member.java
+++ b/src/main/java/site/walkies/walkie/domain/member/entity/Member.java
@@ -68,4 +68,8 @@ public class Member {
     public void changeLevelingEgg(Egg newLevelingEgg) {
         this.levelingEgg = newLevelingEgg;
     }
+
+    public void changeProfileVisibility(Boolean isPublic){
+        this.isPublic = isPublic;
+    }
 }

--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
@@ -49,6 +49,13 @@ public class MemberService {
         return convertMemberToResponseDto(member);
     }
 
+    @Transactional
+    public MemberResponseDto toggleMemberProfileVisibility(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        member.changeProfileVisibility(!member.getIsPublic());
+        return convertMemberToResponseDto(member);
+    }
+
     // Member객체를 MemberResponse DTO로 변경
     public MemberResponseDto convertMemberToResponseDto(Member member){
         return MemberResponseDto.builder()


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #85 

### 📝 작업 내용
- 멤버 id를 통해 현재 상태와 반대로 변경(토글)
![image](https://github.com/user-attachments/assets/182a8787-61ac-49b3-8d0c-9ea96a55b62e)
![image](https://github.com/user-attachments/assets/06b129ec-67d1-403f-b546-107e45e0254c)


### 🙏 리뷰 요구사항
- 원래 memberService 부분 코드를 if-else 문으로 만들었는데, 요즘은 ide가 간단하게 수정도 해주는군요. 고친 방식이 훨씬 깔끔한 것 같아서 그대로 쓰기로 했습니다.
