### PR TITLE
Fix/#93 : egg의 response dto에 memberId도 함께 받아서 처리하도록 수정

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
@@ -105,6 +105,7 @@ public class MemberService {
                 .obtainedDate(egg.getObtainedDate())
                 .picked(egg.getPicked())
                 .userCharacterId(egg.getUserCharacter().getId())
+                .memberId(memberId)
                 .build();
     }
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #93 

### 📝 작업 내용
- egg dto를 응답할 때 memberId를 추가
![image](https://github.com/user-attachments/assets/7add8a3f-bd69-40f0-813a-c3db320d22b6)


### 🙏 리뷰 요구사항
- 
