### PR TITLE
Feat/#100 : 유저 현 위치 기반 주변 스팟 조회하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'  // JSON 처리를 위한 부분
+
+	// h3
+	implementation 'com.uber:h3:3.7.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/site/walkies/walkie/domain/spot/controller/SpotController.java
+++ b/src/main/java/site/walkies/walkie/domain/spot/controller/SpotController.java
@@ -2,14 +2,15 @@ package site.walkies.walkie.domain.spot.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import site.walkies.walkie.domain.spot.service.SpotService;
+import site.walkies.walkie.domain.spot.service.dto.request.SpotNearbyRequestDto;
+import site.walkies.walkie.domain.spot.service.dto.response.SpotNearbyResponseDto;
 import site.walkies.walkie.domain.spot.service.dto.response.SpotResponseDto;
 import site.walkies.walkie.global.auth.dto.MemberPrincipal;
 import site.walkies.walkie.global.web.dto.response.SuccessResponse;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,5 +25,11 @@ public class SpotController {
     ) {
         SpotResponseDto responseDto = spotService.getSpotInfo(spotId, memberPrincipal.getMemberId());
         return SuccessResponse.ok(responseDto);
+    }
+
+    @PostMapping("/nearby")
+    public SuccessResponse<List<SpotNearbyResponseDto>> getNearbySpots(@RequestBody SpotNearbyRequestDto request) {
+        List<SpotNearbyResponseDto> response = spotService.getNearbySpots(request);
+        return SuccessResponse.ok(response);
     }
 }

--- a/src/main/java/site/walkies/walkie/domain/spot/entity/Spot.java
+++ b/src/main/java/site/walkies/walkie/domain/spot/entity/Spot.java
@@ -31,5 +31,5 @@ public class Spot {
     private SpotType type;
 
     @Column(name = "h3_index")
-    private Long h3Index;
+    private String h3Index;
 }

--- a/src/main/java/site/walkies/walkie/domain/spot/repository/SpotRepository.java
+++ b/src/main/java/site/walkies/walkie/domain/spot/repository/SpotRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import site.walkies.walkie.domain.spot.entity.Spot;
 
+import java.util.List;
+
 @Repository
 public interface SpotRepository extends JpaRepository<Spot, Long> {
+    List<Spot> findByH3IndexIn(List<String> h3Indexes);
 }

--- a/src/main/java/site/walkies/walkie/domain/spot/service/SpotService.java
+++ b/src/main/java/site/walkies/walkie/domain/spot/service/SpotService.java
@@ -1,5 +1,6 @@
 package site.walkies.walkie.domain.spot.service;
 
+import com.uber.h3core.H3Core;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,6 +10,8 @@ import site.walkies.walkie.domain.spot.entity.Spot;
 import site.walkies.walkie.domain.spot.entity.SpotPhoto;
 import site.walkies.walkie.domain.spot.repository.SpotPhotoRepository;
 import site.walkies.walkie.domain.spot.repository.SpotRepository;
+import site.walkies.walkie.domain.spot.service.dto.request.SpotNearbyRequestDto;
+import site.walkies.walkie.domain.spot.service.dto.response.SpotNearbyResponseDto;
 import site.walkies.walkie.domain.spot.service.dto.response.SpotResponseDto;
 import site.walkies.walkie.global.web.exception.CustomException;
 import site.walkies.walkie.global.web.exception.ErrorCode;
@@ -16,6 +19,7 @@ import site.walkies.walkie.global.web.exception.ErrorCode;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @Transactional
@@ -25,6 +29,7 @@ public class SpotService {
     private final SpotRepository spotRepository;
     private final SpotPhotoRepository spotPhotoRepository;
     private final ReviewRepository reviewRepository;
+    private final H3Core h3Core;
 
     public SpotResponseDto getSpotInfo(Long spotId, Long memberId) {
         Spot spot = spotRepository.findById(spotId)
@@ -68,8 +73,39 @@ public class SpotService {
                 .daysUntilNextVisit(daysUntilNextVisit)
                 .visitCount(visitCount)
                 .reviewCount(reviewCount)
-                .h3Index(spot.getH3Index())
                 .build();
     }
 
+    public List<SpotNearbyResponseDto> getNearbySpots(SpotNearbyRequestDto request) {
+        int resolution = 9;
+        int k = 30;
+
+        String userH3 = h3Core.geoToH3Address(request.getLatitude(), request.getLongitude(), resolution);
+        // System.out.println("User H3: " + userH3);
+
+        List<String> h3Rings = h3Core.kRing(userH3, k);
+        // System.out.println("H3 Ring Count: " + h3Rings.size());
+        // System.out.println("H3 Ring Sample: " + h3Rings.subList(0, Math.min(5, h3Rings.size())));
+
+        // List<Spot> allSpots = spotRepository.findAll();
+        // System.out.println("All Spot h3Indexes:");
+        // allSpots.forEach(s -> System.out.println("  " + s.getLocationName() + " → " + s.getH3Index()));
+
+        List<Spot> nearbySpots = spotRepository.findByH3IndexIn(h3Rings);
+        // System.out.println("Found Spots: " + nearbySpots.size());
+
+        // String h3FromRequest = h3Core.geoToH3Address(37.5639, 126.9873, 9);
+        // System.out.println("명동성당 직접 계산한 H3: " + h3FromRequest);
+
+
+        return nearbySpots.stream()
+                .map(spot -> SpotNearbyResponseDto.builder()
+                        .id(spot.getId())
+                        .locationName(spot.getLocationName())
+                        .type(spot.getType().name())
+                        .latitude(spot.getLatitude())
+                        .longitude(spot.getLongitude())
+                        .build())
+                .toList();
+    }
 }

--- a/src/main/java/site/walkies/walkie/domain/spot/service/dto/request/SpotNearbyRequestDto.java
+++ b/src/main/java/site/walkies/walkie/domain/spot/service/dto/request/SpotNearbyRequestDto.java
@@ -1,0 +1,11 @@
+package site.walkies.walkie.domain.spot.service.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SpotNearbyRequestDto {
+    private double latitude;
+    private double longitude;
+}

--- a/src/main/java/site/walkies/walkie/domain/spot/service/dto/response/SpotNearbyResponseDto.java
+++ b/src/main/java/site/walkies/walkie/domain/spot/service/dto/response/SpotNearbyResponseDto.java
@@ -1,0 +1,25 @@
+package site.walkies.walkie.domain.spot.service.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SpotNearbyResponseDto {
+    private Long id;
+    private String locationName;
+    private String type;
+    private Double latitude;
+    private Double longitude;
+
+    @Builder
+    public SpotNearbyResponseDto(Long id, String locationName, String type, Double latitude, Double longitude) {
+        this.id = id;
+        this.locationName = locationName;
+        this.type = type;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}
+

--- a/src/main/java/site/walkies/walkie/domain/spot/service/dto/response/SpotResponseDto.java
+++ b/src/main/java/site/walkies/walkie/domain/spot/service/dto/response/SpotResponseDto.java
@@ -20,10 +20,9 @@ public class SpotResponseDto {
     private int daysUntilNextVisit;
     private int visitCount;
     private int reviewCount;
-    private Long h3Index;
 
     @Builder
-    public SpotResponseDto(Long id, String locationName, Double latitude, Double longitude, String streetAddress, String type, List<String> photoUrls, boolean isExplored, int daysUntilNextVisit, int visitCount, int reviewCount, Long h3Index) {
+    public SpotResponseDto(Long id, String locationName, Double latitude, Double longitude, String streetAddress, String type, List<String> photoUrls, boolean isExplored, int daysUntilNextVisit, int visitCount, int reviewCount) {
         this.id = id;
         this.locationName = locationName;
         this.latitude = latitude;
@@ -35,7 +34,6 @@ public class SpotResponseDto {
         this.daysUntilNextVisit = daysUntilNextVisit;
         this.visitCount = visitCount;
         this.reviewCount = reviewCount;
-        this.h3Index = h3Index;
     }
 }
 

--- a/src/main/java/site/walkies/walkie/global/config/H3Config.java
+++ b/src/main/java/site/walkies/walkie/global/config/H3Config.java
@@ -1,0 +1,16 @@
+package site.walkies.walkie.global.config;
+
+import com.uber.h3core.H3Core;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+
+@Configuration
+public class H3Config {
+
+    @Bean
+    public H3Core h3Core() throws IOException {
+        return H3Core.newInstance();
+    }
+}


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #100 

### 📝 작업 내용
- 현재 유저의 위치를 기반으로 반경 5km 내의 스팟들을 추천해 줌
![image](https://github.com/user-attachments/assets/7968a3ab-b51a-473a-94f7-c3b74fdbea02)

- 5km 면 대강 이 정도 범위의 스팟들이 나온다.
![image](https://github.com/user-attachments/assets/8b44264e-de17-4896-8655-9e3d36e7a5b3)

### 🙏 리뷰 요구사항
- 100번째 이슈를 가져가다니 영광입니다.. 게다가 제가 맡은 API 중 가장 중요한 기능이라서 더 의미있군요...
- Service 코드의 주석들은 테스트 출력문인데, 스팟들 추가하게 되면서 계속 테스트용으로 사용할 것 같아서 삭제 안하고 주석처리만 했습니다..!
