### PR TITLE
Fix/#103 : cors 설정 추가, Webmvc 설정 Security로 이동

### DIFF
--- a/src/main/java/site/walkies/walkie/global/config/SecurityConfig.java
+++ b/src/main/java/site/walkies/walkie/global/config/SecurityConfig.java
@@ -9,9 +9,14 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import site.walkies.walkie.domain.member.service.MemberLoginService;
 import site.walkies.walkie.global.auth.filter.JwtFilter;
 import site.walkies.walkie.global.auth.utils.JWTProvider;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -25,6 +30,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
                         .requestMatchers("/auth/login","/swagger-ui.html", "/v3/api-docs/**","/swagger-ui/**").permitAll()
@@ -35,5 +41,20 @@ public class SecurityConfig {
                 .addFilterBefore(new JwtFilter(jwtProvider, memberLoginService), UsernamePasswordAuthenticationFilter.class); // ✅ JwtFilter 직접 생성하여 추가
 
         return http.build();
+    }
+
+    // CORS 설정 명시
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost:5173")); // 프론트 주소 명확히!
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true); // withCredentials 요청 허용
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #103 

### 📝 작업 내용
- `Security` 파일에 `CORS` 설정 추가
- `WebMvcConfig`에 있던 설정도 `SecurityConfig`로 이동

### 🙏 리뷰 요구사항
- 오늘 알게 됐는데, SecurityConfig를 사용하면, `WebMvcConfig` 설정은 무시된다고 합니다. 그래서 기존에 WebMvc에서 설정하던 것도, Security 설정으로 옮겨야 한다고 하네요...
