### PR TITLE
Feat/#105 : Apple 로그인 기능 구현

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/auth/service/AppleService.java
+++ b/src/main/java/site/walkies/walkie/domain/auth/service/AppleService.java
@@ -1,20 +1,29 @@
 package site.walkies.walkie.domain.auth.service;
 
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import site.walkies.walkie.global.auth.utils.AppleJwtValidator;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class AppleService {
 
-    public String verifyIdTokenAndGetUserId(String idToken) {
-        // 1. 애플의 Public Key로 JWT 검증 (애플 공식 문서 참고)
-        // 2. 유효하면 payload에서 sub (고유 사용자 ID) 추출
-        // 3. 검증 실패하면 예외 발생
+    private final AppleJwtValidator appleJwtValidator;
 
+    public String verifyIdTokenAndGetUserId(String idToken) {
         log.info("[AppleService] Received ID Token: {}", idToken);
 
-        String appleUserId = "decoded-apple-user-id"; // 검증 후 user id 추출
+        // 1. id_token 유효성 검증 및 파싱
+        Claims claims = appleJwtValidator.validateAndParseClaims(idToken);
+
+        // 2. sub (Apple 사용자 고유 ID) 추출
+        String appleUserId = claims.getSubject();
+
+        log.info("[AppleService] Extracted Apple User ID (sub): {}", appleUserId);
+
         return appleUserId;
     }
 }

--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
@@ -23,7 +23,7 @@ public class MemberLoginService {
 
     // 애플 로그인
     public MemberResponseDto findOrCreateAppleMember(String appleUserId) {
-        return findOrCreateMember("apple", appleUserId, "애플 사용자");
+        return findOrCreateMember("apple", appleUserId, "사과 워키");
     }
 
     // 기존 멤버인지, 아닌지 확인

--- a/src/main/java/site/walkies/walkie/global/auth/dto/ApplePublicKeyResponse.java
+++ b/src/main/java/site/walkies/walkie/global/auth/dto/ApplePublicKeyResponse.java
@@ -1,0 +1,39 @@
+package site.walkies.walkie.global.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.math.BigInteger;
+import java.util.Base64;
+import java.util.List;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.security.KeyFactory;
+
+@Getter
+public class ApplePublicKeyResponse {
+    @JsonProperty("keys")
+    private List<ApplePublicKey> keys;
+
+    @Getter
+    public static class ApplePublicKey {
+        private String kty;
+        private String kid;
+        private String use;
+        private String alg;
+        private String n;
+        private String e;
+
+        public RSAPublicKey toRSAPublicKey() {
+            try {
+                BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(n));
+                BigInteger exponent = new BigInteger(1, Base64.getUrlDecoder().decode(e));
+                RSAPublicKeySpec spec = new RSAPublicKeySpec(modulus, exponent);
+                KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+                return (RSAPublicKey) keyFactory.generatePublic(spec);
+            } catch (Exception ex) {
+                throw new RuntimeException("[ApplePublicKey] RSA 공개키 생성 실패", ex);
+            }
+        }
+    }
+}

--- a/src/main/java/site/walkies/walkie/global/auth/utils/AppleJwtValidator.java
+++ b/src/main/java/site/walkies/walkie/global/auth/utils/AppleJwtValidator.java
@@ -1,0 +1,41 @@
+package site.walkies.walkie.global.auth.utils;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.SecurityException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import site.walkies.walkie.global.auth.exception.InvalidJWTException;
+
+import java.security.interfaces.RSAPublicKey;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AppleJwtValidator {
+
+    public Claims validateAndParseClaims(String idToken) {
+        try {
+            // 1. JWT header에서 kid 추출
+            String kid = AppleKeyUtils.extractKidFromToken(idToken);
+
+            // 2. kid에 해당하는 Apple 공개키 가져오기
+            RSAPublicKey publicKey = AppleKeyUtils.getApplePublicKeyByKid(kid);
+
+            // 3. JWT 서명 검증 + claims 파싱
+            JwtParser parser = Jwts.parserBuilder()
+                    .setSigningKey(publicKey)
+                    .build();
+
+            Jws<Claims> jws = parser.parseClaimsJws(idToken);
+            return jws.getBody();
+        } catch (SecurityException e) {
+            throw new InvalidJWTException("Apple id_token의 서명 검증에 실패했습니다.", e);
+        } catch (Exception e) {
+            throw new InvalidJWTException("Apple id_token 파싱 중 오류가 발생했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/site/walkies/walkie/global/auth/utils/AppleKeyUtils.java
+++ b/src/main/java/site/walkies/walkie/global/auth/utils/AppleKeyUtils.java
@@ -1,0 +1,52 @@
+package site.walkies.walkie.global.auth.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import site.walkies.walkie.global.auth.dto.ApplePublicKeyResponse;
+import site.walkies.walkie.global.auth.dto.ApplePublicKeyResponse.ApplePublicKey;
+
+import java.io.IOException;
+import java.net.URL;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
+import java.util.Optional;
+
+@Slf4j
+public class AppleKeyUtils {
+
+    private static final String APPLE_PUBLIC_KEYS_URL = "https://appleid.apple.com/auth/keys";
+
+    public static RSAPublicKey getApplePublicKeyByKid(String kid) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            ApplePublicKeyResponse keyResponse = objectMapper.readValue(new URL(APPLE_PUBLIC_KEYS_URL), ApplePublicKeyResponse.class);
+
+            Optional<ApplePublicKey> matchingKey = keyResponse.getKeys().stream()
+                    .filter(key -> key.getKid().equals(kid))
+                    .findFirst();
+
+            if (matchingKey.isEmpty()) {
+                throw new IllegalArgumentException("일치하는 Apple 공개키(kid: " + kid + ")를 찾을 수 없습니다.");
+            }
+
+            return matchingKey.get().toRSAPublicKey();
+        } catch (IOException e) {
+            throw new RuntimeException("Apple 공개키를 가져오는 중 오류 발생", e);
+        }
+    }
+
+    public static String extractKidFromToken(String idToken) {
+        try {
+            String[] parts = idToken.split("\\.");
+            if (parts.length < 2) {
+                throw new IllegalArgumentException("유효하지 않은 JWT 형식입니다.");
+            }
+
+            String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]));
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readTree(headerJson).get("kid").asText();
+        } catch (Exception e) {
+            throw new RuntimeException("JWT header에서 kid를 추출하는 중 오류 발생", e);
+        }
+    }
+}


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #105 

### 📝 작업 내용
- 애플의 id_token(JWT 형식)을 받으면, 토큰을 파싱해서 provider id를 추출함
- 이후, 이미 있는 유저인지 확인하고, 새로운 유저라면 로그인 시키기
![image](https://github.com/user-attachments/assets/958e31c9-89f8-4057-b470-46f5b6b2733f)


### 🙏 리뷰 요구사항
- 애플 id_token 이 jwt로 와서 좀 더 작업하기 수월할거라고 생각했는데, 전혀 아니군요...
