### PR TITLE
Fix/#109 : 로그인(회원가입) 로직을 체크/로그인 & 회원가입 로직으로 분리

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/auth/controller/AuthController.java
+++ b/src/main/java/site/walkies/walkie/domain/auth/controller/AuthController.java
@@ -5,7 +5,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import site.walkies.walkie.domain.auth.service.AuthService;
-import site.walkies.walkie.domain.auth.service.dto.request.LoginRequestDto;
+import site.walkies.walkie.domain.auth.service.dto.request.AuthCheckRequestDto;
+import site.walkies.walkie.domain.auth.service.dto.request.AuthSignupRequestDto;
 import site.walkies.walkie.domain.auth.service.dto.response.LoginResponseDto;
 import site.walkies.walkie.global.web.dto.response.SuccessResponse;
 
@@ -17,18 +18,19 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @Operation(
-            summary = "소셜 로그인 요청",
-            description = "카카오 또는 애플 계정을 통한 소셜 로그인을 처리합니다. " +
-                    "요청 본문에는 provider(kakao 또는 apple)와 각 플랫폼의 access token이 포함됩니다."
-    )
-    @PostMapping("/login")
-    public SuccessResponse<LoginResponseDto> login(@RequestBody LoginRequestDto requestDto) {
-        log.info("[AuthController] Received login request for provider: {}", requestDto.getProvider());
+    @Operation(summary = "소셜 로그인 여부 확인", description = "카카오 또는 애플 accessToken을 기반으로 기존 회원 여부를 확인합니다.")
+    @PostMapping("/check")
+    public SuccessResponse<LoginResponseDto> check(@RequestBody AuthCheckRequestDto requestDto) {
+        log.info("[AuthController] Check login for provider: {}", requestDto.getProvider());
+        LoginResponseDto loginResponseDto = authService.checkUserExists(requestDto);
+        return SuccessResponse.ok(loginResponseDto);
+    }
 
-        // provider에 따라 로그인 처리
-        LoginResponseDto loginResponseDto = authService.login(requestDto);
-
+    @Operation(summary = "소셜 회원가입", description = "카카오 또는 애플 accessToken과 nickname 등을 받아 회원가입을 처리합니다.")
+    @PostMapping("/signup")
+    public SuccessResponse<LoginResponseDto> signup(@RequestBody AuthSignupRequestDto requestDto) {
+        log.info("[AuthController] Signup request for provider: {}", requestDto.getProvider());
+        LoginResponseDto loginResponseDto = authService.signupNewUser(requestDto);
         return SuccessResponse.ok(loginResponseDto);
     }
 }

--- a/src/main/java/site/walkies/walkie/domain/auth/controller/AuthController.java
+++ b/src/main/java/site/walkies/walkie/domain/auth/controller/AuthController.java
@@ -1,6 +1,8 @@
 package site.walkies.walkie.domain.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -18,15 +20,38 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @Operation(summary = "소셜 로그인 여부 확인", description = "카카오 또는 애플 accessToken을 기반으로 기존 회원 여부를 확인합니다.")
-    @PostMapping("/check")
+    @Operation(
+            summary = "소셜 로그인 요청",
+            description = "카카오 또는 애플 계정으로 로그인 시도 시 회원 여부를 확인하고, 기존 회원이면 JWT를 발급합니다.\n\n" +
+                    "- ✅ 기존 회원: accessToken 포함된 응답 반환 (로그인 성공)\n" +
+                    "- ❌ 미가입 회원: accessToken=null 응답 반환 (회원가입 유도)\n" +
+                    "- ⚠️ 유효하지 않은 토큰: 401 Unauthorized 응답 반환"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 결과 반환 (기존 회원 여부에 따라 accessToken 포함 또는 null)"),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 소셜 토큰")
+    })
+    @PostMapping("/login")
     public SuccessResponse<LoginResponseDto> check(@RequestBody AuthCheckRequestDto requestDto) {
         log.info("[AuthController] Check login for provider: {}", requestDto.getProvider());
         LoginResponseDto loginResponseDto = authService.checkUserExists(requestDto);
         return SuccessResponse.ok(loginResponseDto);
     }
 
-    @Operation(summary = "소셜 회원가입", description = "카카오 또는 애플 accessToken과 nickname 등을 받아 회원가입을 처리합니다.")
+    @Operation(
+            summary = "소셜 회원가입 요청",
+            description = "카카오 또는 애플 계정으로 로그인한 사용자에 대해 닉네임을 설정하고 회원가입을 처리합니다.\n\n" +
+                    "- ✅ 회원가입 성공: JWT 토큰 발급\n" +
+                    "- ❌ 이미 가입된 유저: 409 Conflict\n" +
+                    "- ❌ 닉네임 중복/형식 오류 등: 400 Bad Request\n" +
+                    "- ⚠️ 유효하지 않은 토큰: 401 Unauthorized"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원가입 및 토큰 발급 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (닉네임 중복 등)"),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 소셜 토큰"),
+            @ApiResponse(responseCode = "409", description = "이미 가입된 계정")
+    })
     @PostMapping("/signup")
     public SuccessResponse<LoginResponseDto> signup(@RequestBody AuthSignupRequestDto requestDto) {
         log.info("[AuthController] Signup request for provider: {}", requestDto.getProvider());

--- a/src/main/java/site/walkies/walkie/domain/auth/service/AppleService.java
+++ b/src/main/java/site/walkies/walkie/domain/auth/service/AppleService.java
@@ -13,7 +13,7 @@ public class AppleService {
 
     private final AppleJwtValidator appleJwtValidator;
 
-    public String verifyIdTokenAndGetUserId(String idToken) {
+    public String getAppleUserIdFromToken(String idToken) {
         log.info("[AppleService] Received ID Token: {}", idToken);
 
         // 1. id_token 유효성 검증 및 파싱

--- a/src/main/java/site/walkies/walkie/domain/auth/service/AuthService.java
+++ b/src/main/java/site/walkies/walkie/domain/auth/service/AuthService.java
@@ -2,12 +2,15 @@ package site.walkies.walkie.domain.auth.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import site.walkies.walkie.domain.auth.service.dto.request.LoginRequestDto;
+import site.walkies.walkie.domain.auth.service.dto.request.AuthCheckRequestDto;
+import site.walkies.walkie.domain.auth.service.dto.request.AuthSignupRequestDto;
 import site.walkies.walkie.domain.auth.service.dto.response.KakaoUserInfoResponseDto;
 import site.walkies.walkie.domain.auth.service.dto.response.LoginResponseDto;
 import site.walkies.walkie.domain.member.service.MemberLoginService;
 import site.walkies.walkie.domain.member.service.dto.response.MemberResponseDto;
 import site.walkies.walkie.global.auth.utils.JWTProvider;
+import site.walkies.walkie.global.web.exception.CustomException;
+import site.walkies.walkie.global.web.exception.ErrorCode;
 
 @Service
 @RequiredArgsConstructor
@@ -18,21 +21,18 @@ public class AuthService {
     private final MemberLoginService memberLoginService;
     private final JWTProvider jwtProvider;
 
-    public LoginResponseDto login(LoginRequestDto requestDto) {
-        MemberResponseDto memberResponseDto;
+    public LoginResponseDto checkUserExists(AuthCheckRequestDto requestDto) {
+        MemberResponseDto memberResponseDto = getExistingMemberIfExists(requestDto);
 
-        switch (requestDto.getProvider().toLowerCase()) {
-            case "kakao":
-                memberResponseDto = loginWithKakao(requestDto.getLoginAccessToken());
-                break;
-            case "apple":
-                memberResponseDto = loginWithApple(requestDto.getLoginAccessToken());
-                break;
-            default:
-                throw new IllegalArgumentException("지원하지 않는 로그인 방식입니다.");
+        if (memberResponseDto == null) {
+            // 회원이 없는 경우: 프론트에서 회원가입 유도
+            return LoginResponseDto.builder()
+                    .provider(requestDto.getProvider())
+                    .accessToken(null)
+                    .refreshToken(null)
+                    .build();
         }
 
-        // JWT 토큰 생성
         String accessToken = jwtProvider.buildAccessToken(
                 memberResponseDto.getProviderId(),
                 memberResponseDto.getId()
@@ -41,17 +41,55 @@ public class AuthService {
         return LoginResponseDto.builder()
                 .provider(memberResponseDto.getProvider())
                 .accessToken(accessToken)
-                .refreshToken(null) // Refresh Token은 추후 구현
+                .refreshToken(null)
                 .build();
     }
 
-    private MemberResponseDto loginWithKakao(String accessToken) {
-        KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo(accessToken);
-        return memberLoginService.findOrCreateKakaoMember(userInfo);
+    public LoginResponseDto signupNewUser(AuthSignupRequestDto requestDto) {
+        MemberResponseDto memberResponseDto;
+
+        switch (requestDto.getProvider().toLowerCase()) {
+            case "kakao":
+                KakaoUserInfoResponseDto kakaoUserInfo = kakaoService.getUserInfo(requestDto.getLoginAccessToken());
+                memberResponseDto = memberLoginService.createKakaoMember(kakaoUserInfo, requestDto.getNickname());
+                break;
+            case "apple":
+                String appleUserId = appleService.getAppleUserIdFromToken(requestDto.getLoginAccessToken());
+                memberResponseDto = memberLoginService.createAppleMember(appleUserId, requestDto.getNickname());
+                break;
+            default:
+                throw new IllegalArgumentException("지원하지 않는 로그인 방식입니다.");
+        }
+
+        String accessToken = jwtProvider.buildAccessToken(
+                memberResponseDto.getProviderId(),
+                memberResponseDto.getId()
+        );
+
+        return LoginResponseDto.builder()
+                .provider(memberResponseDto.getProvider())
+                .accessToken(accessToken)
+                .refreshToken(null)
+                .build();
     }
 
-    private MemberResponseDto loginWithApple(String accessToken) {
-        String appleUserId = appleService.verifyIdTokenAndGetUserId(accessToken);
-        return memberLoginService.findOrCreateAppleMember(appleUserId);
+    private MemberResponseDto getExistingMemberIfExists(AuthCheckRequestDto requestDto) {
+        try {
+            switch (requestDto.getProvider().toLowerCase()) {
+                case "kakao":
+                    KakaoUserInfoResponseDto kakaoUserInfo = kakaoService.getUserInfo(requestDto.getLoginAccessToken());
+                    return memberLoginService.findKakaoMember(kakaoUserInfo);
+                case "apple":
+                    String appleUserId = appleService.getAppleUserIdFromToken(requestDto.getLoginAccessToken());
+                    return memberLoginService.findAppleMember(appleUserId);
+                default:
+                    throw new IllegalArgumentException("지원하지 않는 로그인 방식입니다.");
+            }
+        } catch (CustomException e) {
+            if (e.getErrorCode() == ErrorCode.USER_NOT_FOUND) {
+                return null;
+            }
+            throw e;
+        }
     }
 }

--- a/src/main/java/site/walkies/walkie/domain/auth/service/dto/request/AuthCheckRequestDto.java
+++ b/src/main/java/site/walkies/walkie/domain/auth/service/dto/request/AuthCheckRequestDto.java
@@ -1,0 +1,11 @@
+package site.walkies.walkie.domain.auth.service.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AuthCheckRequestDto {
+    private String provider;  // "kakao" 또는 "apple"
+    private String loginAccessToken;
+}

--- a/src/main/java/site/walkies/walkie/domain/auth/service/dto/request/AuthSignupRequestDto.java
+++ b/src/main/java/site/walkies/walkie/domain/auth/service/dto/request/AuthSignupRequestDto.java
@@ -1,0 +1,12 @@
+package site.walkies.walkie.domain.auth.service.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AuthSignupRequestDto {
+    private String provider;           // "kakao" 또는 "apple"
+    private String loginAccessToken;   // accessToken 또는 id_token
+    private String nickname;           // 사용자 입력 닉네임
+}

--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
@@ -15,22 +15,29 @@ public class MemberLoginService {
 
     private final MemberRepository memberRepository;
 
-    // 카카오 로그인
-    public MemberResponseDto findOrCreateKakaoMember(KakaoUserInfoResponseDto userInfo) {
+    // 로그인 확인용 (회원 조회만)
+    public MemberResponseDto findKakaoMember(KakaoUserInfoResponseDto userInfo) {
         String providerId = userInfo.getId().toString();
-        return findOrCreateMember("kakao", providerId, userInfo.getKakaoAccount().getProfile().getNickName());
-    }
-
-    // 애플 로그인
-    public MemberResponseDto findOrCreateAppleMember(String appleUserId) {
-        return findOrCreateMember("apple", appleUserId, "사과 워키");
-    }
-
-    // 기존 멤버인지, 아닌지 확인
-    private MemberResponseDto findOrCreateMember(String provider, String providerId, String nickname) {
         return memberRepository.findByProviderId(providerId)
                 .map(this::convertMemberToMemberResponseDto)
-                .orElseGet(() -> createMember(provider, providerId, nickname));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    public MemberResponseDto findAppleMember(String appleUserId) {
+        return memberRepository.findByProviderId(appleUserId)
+                .map(this::convertMemberToMemberResponseDto)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    // 카카오 회원가입 처리
+    public MemberResponseDto createKakaoMember(KakaoUserInfoResponseDto userInfo, String nickname) {
+        String providerId = userInfo.getId().toString();
+        return createMember("kakao", providerId, nickname);
+    }
+
+    // 애플 회원가입 처리
+    public MemberResponseDto createAppleMember(String appleUserId, String nickname) {
+        return createMember("apple", appleUserId, nickname);
     }
 
     // memberId로 DB에서 정보 가져오기

--- a/src/main/java/site/walkies/walkie/domain/spot/entity/SpotPhoto.java
+++ b/src/main/java/site/walkies/walkie/domain/spot/entity/SpotPhoto.java
@@ -16,7 +16,7 @@ public class SpotPhoto {
     @JoinColumn(name = "spot_id")
     private Spot spot;
 
-    @Column(name = "photo_url")
+    @Column(name = "photo_url", length = 1024)
     private String photoUrl;
 }
 

--- a/src/main/java/site/walkies/walkie/global/auth/filter/JwtFilter.java
+++ b/src/main/java/site/walkies/walkie/global/auth/filter/JwtFilter.java
@@ -40,6 +40,7 @@ public class JwtFilter extends GenericFilterBean {
         // JWT가 필요 없는 API 리스트 (로그인, 회원가입 등)
         List<String> excludedUrls = List.of(
                 "/api/v1/auth/login",
+                "/api/v1/auth/signup",
                 "/api/v1/swagger-ui.html",
                 "/api/v1/v3/api-docs/**",
                 "/swagger-ui/**"

--- a/src/main/java/site/walkies/walkie/global/config/SecurityConfig.java
+++ b/src/main/java/site/walkies/walkie/global/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
-                        .requestMatchers("/auth/login","/swagger-ui.html", "/v3/api-docs/**","/swagger-ui/**").permitAll()
+                        .requestMatchers("/auth/login","/auth/signup","/swagger-ui.html", "/v3/api-docs/**","/swagger-ui/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .formLogin(httpSecurityFormLoginConfigurer -> httpSecurityFormLoginConfigurer.disable()) // ✅ 로그인 폼 비활성화 (SNS 로그인만 사용)

--- a/src/main/java/site/walkies/walkie/global/web/exception/CustomException.java
+++ b/src/main/java/site/walkies/walkie/global/web/exception/CustomException.java
@@ -4,10 +4,10 @@ import lombok.Getter;
 
 @Getter
 public class CustomException extends RuntimeException {
-    private final ErrorCode errorcode;
+    private final ErrorCode errorCode;
 
-    public CustomException(ErrorCode errorcode) {
-        super(errorcode.getMessage());
-        this.errorcode = errorcode;
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
     }
 }

--- a/src/main/java/site/walkies/walkie/global/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/site/walkies/walkie/global/web/exception/GlobalExceptionHandler.java
@@ -17,11 +17,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ExceptionResponse> handleCustomException(CustomException ex){
         log.error("CustomException 발생: ", ex);
         ExceptionResponse response = ExceptionResponse.builder()
-                .status(ex.getErrorcode().getHttpStatus().value())
+                .status(ex.getErrorCode().getHttpStatus().value())
                 .message(ex.getMessage())
                 .build();
 
-        return new ResponseEntity<>(response, ex.getErrorcode().getHttpStatus());
+        return new ResponseEntity<>(response, ex.getErrorCode().getHttpStatus());
     }
 
     // 그 외의 모든 Exception에 대한 처리


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #109 

### 📝 작업 내용
- 기존 로직 : 로그인 하나로 요청 시 계정이 있다면 로그인, 없으면 만들고 로그인
- 바뀐 로직 : 
    - 체크/로그인: 계정이 있나 체크, 없으면 null 보냄. 있으면 access Token 보냄
    - 회원가입: sns token과 닉네임 보내서 유저 등록

회원 없는 경우
![image](https://github.com/user-attachments/assets/8cb7ae3d-8079-4232-99fb-a6c71f40268a)

회원 있는 경우
![image](https://github.com/user-attachments/assets/2f499ade-3448-4836-9257-c0ced54013a3)


### 🙏 리뷰 요구사항
- 
