### PR TITLE
Hotfix/#115 : swagger가 띄워진 `"https://truthguard.site"` 주소를 CORS 허용 설정에 추가

### DIFF
--- a/src/main/java/site/walkies/walkie/global/config/SecurityConfig.java
+++ b/src/main/java/site/walkies/walkie/global/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:5173", "https://walkie-virid.vercel.app", "https://walkie-frontend.vercel.app")); // 프론트 주소 명확히!
+        config.setAllowedOrigins(List.of("https://truthguard.site", "http://localhost:5173", "https://walkie-virid.vercel.app", "https://walkie-frontend.vercel.app")); // 프론트 주소 명확히!
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true); // withCredentials 요청 허용


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #115

### 📝 작업 내용
- 

### 🙏 리뷰 요구사항
- 
