### PR TITLE
Feat/#126 : 멤버 로그아웃 API 구현

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/auth/controller/AuthController.java
+++ b/src/main/java/site/walkies/walkie/domain/auth/controller/AuthController.java
@@ -5,12 +5,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import site.walkies.walkie.domain.auth.service.AuthService;
 import site.walkies.walkie.domain.auth.service.dto.request.AuthCheckRequestDto;
 import site.walkies.walkie.domain.auth.service.dto.request.AuthSignupRequestDto;
 import site.walkies.walkie.domain.auth.service.dto.request.RefreshTokenRequestDto;
 import site.walkies.walkie.domain.auth.service.dto.response.LoginResponseDto;
+import site.walkies.walkie.domain.member.service.dto.response.MemberResponseDto;
+import site.walkies.walkie.global.auth.dto.MemberPrincipal;
 import site.walkies.walkie.global.web.dto.response.SuccessResponse;
 
 @Slf4j
@@ -75,6 +78,17 @@ public class AuthController {
     public SuccessResponse<LoginResponseDto> refreshToken(@RequestBody RefreshTokenRequestDto requestDto) {
         LoginResponseDto response = authService.refreshAccessToken(requestDto);
         return SuccessResponse.ok(response);
+    }
+
+
+    @Operation(
+            summary = "사용자 로그아웃",
+            description = "사용자의 refresh token 정보를 삭제하여 로그아웃 시킵니다."
+    )
+    @PostMapping("/logout")
+    public SuccessResponse<MemberResponseDto> logout(@AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+        MemberResponseDto memberResponseDto = authService.logout(memberPrincipal.getMemberId());
+        return SuccessResponse.ok(memberResponseDto);
     }
 
 }

--- a/src/main/java/site/walkies/walkie/domain/auth/service/AuthService.java
+++ b/src/main/java/site/walkies/walkie/domain/auth/service/AuthService.java
@@ -145,4 +145,23 @@ public class AuthService {
                 .build();
     }
 
+
+    // 멤버 로그아웃
+    public MemberResponseDto logout(Long memberId){
+        Member member = memberLoginService.findMemberById(memberId);
+        memberRefreshTokenService.deleteByMember(member);
+        return MemberResponseDto.builder()
+                .id(member.getId())
+                .nickname(member.getNickname())
+                .provider(member.getProvider())
+                .providerId(member.getProviderId())
+                .exploredSpot(member.getExploredSpot())
+                .recordedSpot(member.getRecordedSpot())
+                .userCharacterId(member.getLevelingUserCharacter() != null ? member.getLevelingUserCharacter().getId() : null)
+                .eggId(member.getLevelingEgg() != null ? member.getLevelingEgg().getId() : null)
+                .memberTier(member.getMemberTier())
+                .isPublic(member.getIsPublic())
+                .build();
+    }
+
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #126 

### 📝 작업 내용
- 사용자의 jwt 토큰에서 멤버 정보를 꺼내서 리프레시 토큰 삭제
- 테스트 화면
- ![image](https://github.com/user-attachments/assets/a1b2bb14-b628-4462-bc6b-7e703a414661)

- DB 데이터
    - 로그인 시 (refresh 토큰 생성)
    - ![image](https://github.com/user-attachments/assets/8390c3b9-0249-4198-a72d-b6facad4110f)
    - 로그아웃 시 (refresh 토큰 삭제)
    - ![image](https://github.com/user-attachments/assets/73644c91-6fc2-475b-9c0c-12b2022b580d)


### 🙏 리뷰 요구사항
- 
