### PR TITLE
Feat/#129 : 멤버의 기록한 스팟 개수 리턴 API 구현

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/member/controller/MemberController.java
+++ b/src/main/java/site/walkies/walkie/domain/member/controller/MemberController.java
@@ -91,5 +91,16 @@ public class MemberController {
         MemberResponseDto memberResponseDto = memberService.toggleMemberProfileVisibility(memberPrincipal.getMemberId());
         return SuccessResponse.updated(memberResponseDto);
     }
+
+    @Operation(
+            summary = "사용자의 기록한 스팟 개수 조회",
+            description = "메인 화면에서 사용자의 기록한 스팟 개수를 조회할 때 사용합니다."
+    )
+    @GetMapping("/recorded-spot")
+    public SuccessResponse<Integer> getMemberRecordedSpot(@AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+        Integer memberRecordedSpot = memberService.getMemberRecordedSpot(memberPrincipal.getMemberId());
+        return SuccessResponse.ok(memberRecordedSpot);
+    }
+
 }
 

--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
@@ -131,4 +131,10 @@ public class MemberService {
                 .exploredSpot(member.getExploredSpot())
                 .build();
     }
+
+    // 멤버가 기록한 스팟 개수 조회
+    public Integer getMemberRecordedSpot(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return member.getRecordedSpot();
+    }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #129 

### 📝 작업 내용
- 유저의 토큰을 통해 recorded spot 조회 후 개수 반환
![image](https://github.com/user-attachments/assets/84b713e7-78ee-42bb-acbd-95f90862ca13)

### 🙏 리뷰 요구사항
- 지금 리뷰 작성 시 유저의 `recordedSpot` 과 `exploredSpot`을 업데이트 하는 코드가 필요할 것 같습니다!
