### PR TITLE
Fix/#127 : 멤버의 알이 없을 때, null을 넣는 객체를 보내도록 변경

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
@@ -96,6 +96,12 @@ public class MemberService {
 
         Egg egg = member.getLevelingEgg();
 
+        if (egg == null) {
+            return EggResponse.builder()
+                    .memberId(memberId)
+                    .build();
+        }
+
         return EggResponse.builder()
                 .eggId(egg.getId())
                 .rank(egg.getRank())


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #127 

### 📝 작업 내용
- 멤버의 알이 없을 때, null을 넣은 객체를 반환하도록 함
- ![image](https://github.com/user-attachments/assets/a57ee422-e072-460a-a185-2c1c4c6a1248)


### 🙏 리뷰 요구사항
- 
