### PR TITLE
Fix/#151 : 유저 주변 스팟 조회 시, 방문 여부에 따라 응답 달라지도록 수정

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/site/walkies/walkie/domain/review/repository/ReviewRepository.java
@@ -30,4 +30,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     // 삭제를 위한 userId를 통한 조회
     List<Review> findByMemberId(Long memberId);
+
+    // 스팟에 대한 유저의 리뷰 개수 조회
+    int countByMemberIdAndSpotIdAndDeleteCdFalse(Long memberId, Long spotId);
 }

--- a/src/main/java/site/walkies/walkie/domain/spot/controller/SpotController.java
+++ b/src/main/java/site/walkies/walkie/domain/spot/controller/SpotController.java
@@ -28,8 +28,11 @@ public class SpotController {
     }
 
     @PostMapping("/nearby")
-    public SuccessResponse<List<SpotNearbyResponseDto>> getNearbySpots(@RequestBody SpotNearbyRequestDto request) {
-        List<SpotNearbyResponseDto> response = spotService.getNearbySpots(request);
+    public SuccessResponse<List<SpotNearbyResponseDto>> getNearbySpots(
+            @AuthenticationPrincipal MemberPrincipal memberPrincipal,
+            @RequestBody SpotNearbyRequestDto request
+    ) {
+        List<SpotNearbyResponseDto> response = spotService.getNearbySpots(request, memberPrincipal.getMemberId());
         return SuccessResponse.ok(response);
     }
 }

--- a/src/main/java/site/walkies/walkie/domain/spot/service/SpotService.java
+++ b/src/main/java/site/walkies/walkie/domain/spot/service/SpotService.java
@@ -19,7 +19,6 @@ import site.walkies.walkie.global.web.exception.ErrorCode;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.Set;
 
 @Service
 @Transactional
@@ -76,7 +75,7 @@ public class SpotService {
                 .build();
     }
 
-    public List<SpotNearbyResponseDto> getNearbySpots(SpotNearbyRequestDto request) {
+    public List<SpotNearbyResponseDto> getNearbySpots(SpotNearbyRequestDto request, Long memberId) {
         int resolution = 9;
         int k = 30;
 
@@ -97,15 +96,18 @@ public class SpotService {
         // String h3FromRequest = h3Core.geoToH3Address(37.5639, 126.9873, 9);
         // System.out.println("명동성당 직접 계산한 H3: " + h3FromRequest);
 
-
         return nearbySpots.stream()
                 .map(spot -> SpotNearbyResponseDto.builder()
                         .id(spot.getId())
                         .locationName(spot.getLocationName())
-                        .type(spot.getType().name())
+                        .type(isVisitedSpot(spot.getId(), memberId) ? spot.getType().name() : spot.getType().name()+"_VISITED")
                         .latitude(spot.getLatitude())
                         .longitude(spot.getLongitude())
                         .build())
                 .toList();
+    }
+
+    private boolean isVisitedSpot(Long nearSpotId, Long memberId){
+        return reviewRepository.countByMemberIdAndSpotIdAndDeleteCdFalse(memberId ,nearSpotId) > 0;
     }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #151 

### 📝 작업 내용
- 현재, 유저가 방문한 스팟이면 type뒤에 `_VISITED`가 함께 나옴
- 실행 화면
- ![image](https://github.com/user-attachments/assets/1f644cc8-661d-4d79-b5eb-9900edbf6e4a)


### 🙏 리뷰 요구사항
- 현재 스팟 타입은 수정 예정이지만, 일단 머지하고 나중에 바꿔도 상관없을 것 같아서 지금 작업시에는 이전 타입 사용하였습니다.
