### PR TITLE
Refactor/#155 : Spot 카테고리 마이그레이션 및 데이터 변환 작업

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/spot/entity/Spot.java
+++ b/src/main/java/site/walkies/walkie/domain/spot/entity/Spot.java
@@ -2,7 +2,7 @@ package site.walkies.walkie.domain.spot.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
-import site.walkies.walkie.domain.spot.enums.SpotType;
+import site.walkies.walkie.domain.spot.enums.SpotKeyword;
 
 @Entity
 @Table(name = "spot")
@@ -28,8 +28,12 @@ public class Spot {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "type")
-    private SpotType type;
+    private SpotKeyword keyword;
 
     @Column(name = "h3_index")
     private String h3Index;
+
+    public void changeKeyword(SpotKeyword spotKeyword) {
+        this.keyword = spotKeyword;
+    }
 }

--- a/src/main/java/site/walkies/walkie/domain/spot/enums/SpotKeyword.java
+++ b/src/main/java/site/walkies/walkie/domain/spot/enums/SpotKeyword.java
@@ -1,9 +1,6 @@
 package site.walkies.walkie.domain.spot.enums;
 
 public enum SpotKeyword {
-    PARK,
-    CAFE,
-    ETC,
     NATURE,
     HUMANITIES,
     SPORTS,

--- a/src/main/java/site/walkies/walkie/domain/spot/enums/SpotKeyword.java
+++ b/src/main/java/site/walkies/walkie/domain/spot/enums/SpotKeyword.java
@@ -1,0 +1,12 @@
+package site.walkies.walkie.domain.spot.enums;
+
+public enum SpotKeyword {
+    PARK,
+    CAFE,
+    ETC,
+    NATURE,
+    HUMANITIES,
+    SPORTS,
+    SHOPPING,
+    FOOD
+}

--- a/src/main/java/site/walkies/walkie/domain/spot/enums/SpotType.java
+++ b/src/main/java/site/walkies/walkie/domain/spot/enums/SpotType.java
@@ -1,5 +1,6 @@
 package site.walkies.walkie.domain.spot.enums;
 
+@Deprecated
 public enum SpotType {
     CAFE,
     PARK,

--- a/src/main/java/site/walkies/walkie/domain/spot/migration/SpotKeywordMigrationRunner.java
+++ b/src/main/java/site/walkies/walkie/domain/spot/migration/SpotKeywordMigrationRunner.java
@@ -1,0 +1,56 @@
+package site.walkies.walkie.domain.spot.migration;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import site.walkies.walkie.domain.spot.entity.Spot;
+import site.walkies.walkie.domain.spot.enums.SpotKeyword;
+import site.walkies.walkie.domain.spot.repository.SpotRepository;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SpotKeywordMigrationRunner implements ApplicationRunner {
+
+    private final SpotRepository spotRepository;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        log.info("▶️ Spot Keyword Migration 시작");
+
+        var spots = spotRepository.findAll();
+
+        for (Spot spot : spots) {
+            SpotKeyword keyword = spot.getKeyword();
+
+            if (keyword == null) {
+                log.warn("⚠️ Spot ID {}: keyword가 null입니다. 건너뜀", spot.getId());
+                continue;
+            }
+
+            switch (keyword.name()) {
+                case "PARK" -> {
+                    spot.changeKeyword(SpotKeyword.NATURE);
+                    log.info("✅ Spot ID {}: PARK -> NATURE", spot.getId());
+                }
+                case "CAFE" -> {
+                    spot.changeKeyword(SpotKeyword.FOOD);
+                    log.info("✅ Spot ID {}: CAFE -> FOOD", spot.getId());
+                }
+                case "ETC" -> {
+                    spot.changeKeyword(SpotKeyword.HUMANITIES);
+                    log.info("✅ Spot ID {}: ETC -> HUMANITIES", spot.getId());
+                }
+                default -> {
+                    log.warn("⚠️ Spot ID {}: 예상치 못한 keyword {}", spot.getId(), keyword);
+                }
+            }
+        }
+
+        log.info("🏁 Spot Keyword Migration 완료");
+    }
+}

--- a/src/main/java/site/walkies/walkie/domain/spot/migration/SpotKeywordMigrationRunner.java
+++ b/src/main/java/site/walkies/walkie/domain/spot/migration/SpotKeywordMigrationRunner.java
@@ -11,7 +11,7 @@ import site.walkies.walkie.domain.spot.enums.SpotKeyword;
 import site.walkies.walkie.domain.spot.repository.SpotRepository;
 
 @Slf4j
-@Component
+// @Component
 @RequiredArgsConstructor
 public class SpotKeywordMigrationRunner implements ApplicationRunner {
 

--- a/src/main/java/site/walkies/walkie/domain/spot/service/SpotService.java
+++ b/src/main/java/site/walkies/walkie/domain/spot/service/SpotService.java
@@ -66,7 +66,7 @@ public class SpotService {
                 .latitude(spot.getLatitude())
                 .longitude(spot.getLongitude())
                 .streetAddress(spot.getStreetAddress())
-                .type(spot.getType().name()) // enum -> String
+                .type(spot.getKeyword().name()) // enum -> String
                 .photoUrls(photoUrls)
                 .isExplored(isExplored)
                 .daysUntilNextVisit(daysUntilNextVisit)
@@ -100,7 +100,7 @@ public class SpotService {
                 .map(spot -> SpotNearbyResponseDto.builder()
                         .id(spot.getId())
                         .locationName(spot.getLocationName())
-                        .type(isVisitedSpot(spot.getId(), memberId) ? spot.getType().name() : spot.getType().name()+"_VISITED")
+                        .type(isVisitedSpot(spot.getId(), memberId) ? spot.getKeyword().name() : spot.getKeyword().name()+"_VISITED")
                         .latitude(spot.getLatitude())
                         .longitude(spot.getLongitude())
                         .build())


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #155 

### 📝 작업 내용
- SpotType(Enum) → SpotKeyword(Enum)로 카테고리 체계 개편
- Spot 엔티티의 keyword 필드 타입을 SpotType → SpotKeyword로 변경
- SpotKeywordMigrationRunner 작성 및 1회성 데이터 변환 실행
- 기존 데이터(PARK, CAFE, ETC)를 새로운 키워드(NATURE, FOOD, HUMANITIES)로 변환
- DB 'spot' 테이블의 'type' 컬럼 ENUM 값 수정 (NATURE, HUMANITIES, SPORTS, SHOPPING, FOOD 추가)
- 변환 완료 후 SpotKeyword Enum에서 임시 값(PARK, CAFE, ETC) 삭제
- SpotKeywordMigrationRunner의 @Component 주석 처리하여 기록 보존
- 실행 화면
    - 변경 전 DB
    - ![image](https://github.com/user-attachments/assets/3fe9376c-031d-4e2b-9b91-f93a761daceb)
    - 변경 후 DB
    - ![image](https://github.com/user-attachments/assets/3d661595-06ba-4e18-83dd-6e3498ae3e71)


### 🙏 리뷰 요구사항
- SpotKeyword Enum 변경 및 엔티티 수정이 누락된 부분 없이 잘 적용되었는지 확인 부탁드립니다.
- SpotKeywordMigrationRunner가 @Component 주석 처리되어 추가 실행되지 않는지 검토 부탁드립니다.
- 혹시 추가적으로 SpotKeyword 관련 API 응답이나 사용처에서 수정 필요한 부분이 있는지 검토해주시면 감사하겠습니다.
