### PR TITLE
Fix/#157 : 회원가입 시 중복된 계정을 등록하려고 할 때 예외처리 로직 추가

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/member/repository/MemberRepository.java
+++ b/src/main/java/site/walkies/walkie/domain/member/repository/MemberRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByProviderId(String providerId);
+
+    boolean existsByProviderAndProviderId(String provider, String providerId);
 }

--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
@@ -52,6 +52,13 @@ public class MemberLoginService {
 
     // 멤버 생성
     private MemberResponseDto createMember(String provider, String providerId, String nickname) {
+        // 기존에 있는 회원인지 조회
+        boolean existsMember = memberRepository.existsByProviderAndProviderId(provider, providerId);
+
+        if(existsMember) {
+            throw new CustomException(ErrorCode.ALREADY_REGISTERED_USER);
+        }
+
         Member newMember = Member.builder()
                 .provider(provider)
                 .providerId(providerId)

--- a/src/main/java/site/walkies/walkie/global/web/exception/ErrorCode.java
+++ b/src/main/java/site/walkies/walkie/global/web/exception/ErrorCode.java
@@ -8,6 +8,7 @@ public enum ErrorCode {
     // 멤버 관련 예외
     // 아래는 예시입니다. 오류 상황에 맞는 이름과 메시지를 만들고, 사용할 HttpStatus를 선택하면 됩니다.
     USER_NOT_FOUND("존재하지 않는 유저입니다.", HttpStatus.UNAUTHORIZED),
+    ALREADY_REGISTERED_USER("이미 계정이 등록된 유저입니다.", HttpStatus.CONFLICT),
     INVALID_REFRESH_TOKEN("유효하지 않은 리프레시 토큰입니다.", HttpStatus.UNAUTHORIZED),
     //    USER_VALIDATION_ERROR("유저 검증 오류가 발생했습니다.", HttpStatus.UNAUTHORIZED),
     //    INVALID_PASSWORD("올바르지 않은 비밀번호입니다.", HttpStatus.UNAUTHORIZED),


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #157 

### 📝 작업 내용
- `provider` 와 `providerId` 로 중복 회원을 검사하여, 이미 존재하는 회원일 경우 `409 CONFLICT` 예외 던짐
- 실행 화면
- ![image](https://github.com/user-attachments/assets/647fc119-9f50-49cf-98ae-dcb76e419a0d)


### 🙏 리뷰 요구사항
- 
