### PR TITLE
Feat/#131 : 회원 탈퇴 기능 추가

### DIFF
--- a/src/main/java/site/walkies/walkie/WalkieApplication.java
+++ b/src/main/java/site/walkies/walkie/WalkieApplication.java
@@ -3,7 +3,9 @@ package site.walkies.walkie;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication()
 public class WalkieApplication {
 

--- a/src/main/java/site/walkies/walkie/domain/member/controller/MemberController.java
+++ b/src/main/java/site/walkies/walkie/domain/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import site.walkies.walkie.domain.egg.entity.Egg;
 import site.walkies.walkie.domain.egg.service.dto.response.EggResponse;
 import site.walkies.walkie.domain.egg.service.dto.response.GetEggResponse;
 import site.walkies.walkie.domain.character.service.dto.response.GetCharacterResponse;
+import site.walkies.walkie.domain.member.service.MemberDeletionService;
 import site.walkies.walkie.domain.member.service.MemberService;
 import site.walkies.walkie.domain.member.service.dto.request.MemberUpdateCharacterRequestDto;
 import site.walkies.walkie.domain.member.service.dto.request.MemberUpdateLevelingEggRequestDto;
@@ -22,6 +23,7 @@ import site.walkies.walkie.global.web.dto.response.SuccessResponse;
 public class MemberController {
 
     private final MemberService memberService;
+    private final MemberDeletionService memberDeletionService;
 
     @Operation(
             summary = "사용자 정보 조회",
@@ -103,5 +105,14 @@ public class MemberController {
         return SuccessResponse.ok(memberRecordedSpot);
     }
 
+    @Operation(
+            summary = "사용자의 기록한 스팟 개수 조회",
+            description = "메인 화면에서 사용자의 기록한 스팟 개수를 조회할 때 사용합니다."
+    )
+    @DeleteMapping("")
+    public SuccessResponse<Long> deleteMember(@AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+        Long deletedId = memberDeletionService.softDeleteMember(memberPrincipal.getMemberId());
+        return SuccessResponse.deleted(deletedId);
+    }
 }
 

--- a/src/main/java/site/walkies/walkie/domain/member/controller/MemberController.java
+++ b/src/main/java/site/walkies/walkie/domain/member/controller/MemberController.java
@@ -106,8 +106,8 @@ public class MemberController {
     }
 
     @Operation(
-            summary = "사용자의 기록한 스팟 개수 조회",
-            description = "메인 화면에서 사용자의 기록한 스팟 개수를 조회할 때 사용합니다."
+            summary = "회원 탈퇴",
+            description = "회원 탈퇴 요청을 보낼 때 사용합니다."
     )
     @DeleteMapping("")
     public SuccessResponse<Long> deleteMember(@AuthenticationPrincipal MemberPrincipal memberPrincipal) {

--- a/src/main/java/site/walkies/walkie/domain/member/entity/Member.java
+++ b/src/main/java/site/walkies/walkie/domain/member/entity/Member.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import site.walkies.walkie.domain.character.entity.UserCharacter;
 import site.walkies.walkie.domain.egg.entity.Egg;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "member")
 @Getter
@@ -47,8 +49,14 @@ public class Member {
     @JoinColumn(name = "leveling_character_id")
     private UserCharacter levelingUserCharacter;
 
+    @Column(name = "delete_cd")
+    private Boolean deleteCd;
+
+    @Column(name = "delete_requested_at")
+    private LocalDateTime deleteRequestedAt;
+
     @Builder
-    public Member(Long id, String providerId, String provider, String nickname, Integer exploredSpot, Integer recordedSpot, Boolean isPublic, String memberTier, Egg levelingEgg, UserCharacter levelingUserCharacter) {
+    public Member(Long id, String providerId, String provider, String nickname, Integer exploredSpot, Integer recordedSpot, Boolean isPublic, String memberTier, Egg levelingEgg, UserCharacter levelingUserCharacter, Boolean deleteCd) {
         this.id = id;
         this.providerId = providerId;
         this.provider = provider;
@@ -59,6 +67,7 @@ public class Member {
         this.memberTier = memberTier;
         this.levelingEgg = levelingEgg;
         this.levelingUserCharacter = levelingUserCharacter;
+        this.deleteCd = deleteCd;
     }
 
     public void changeNickname(String newNickname) {
@@ -75,5 +84,10 @@ public class Member {
 
     public void changeProfileVisibility(Boolean isPublic){
         this.isPublic = isPublic;
+    }
+
+    public void markDeleted(LocalDateTime now) {
+        this.deleteCd = true;
+        this.deleteRequestedAt = now;
     }
 }

--- a/src/main/java/site/walkies/walkie/domain/member/repository/MemberRepository.java
+++ b/src/main/java/site/walkies/walkie/domain/member/repository/MemberRepository.java
@@ -4,11 +4,16 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import site.walkies.walkie.domain.member.entity.Member;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.List;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByProviderId(String providerId);
 
     boolean existsByProviderAndProviderId(String provider, String providerId);
+
+    // 스케쥴러로 매일 삭제할 것들 탐색하기
+    List<Member> findAllByDeleteCdTrueAndDeleteRequestedAtBefore(LocalDateTime before);
 }

--- a/src/main/java/site/walkies/walkie/domain/member/scheduler/MemberCleanupScheduler.java
+++ b/src/main/java/site/walkies/walkie/domain/member/scheduler/MemberCleanupScheduler.java
@@ -1,0 +1,20 @@
+package site.walkies.walkie.domain.member.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import site.walkies.walkie.domain.member.service.MemberDeletionService;
+
+@Component
+@RequiredArgsConstructor
+public class MemberCleanupScheduler {
+
+    private final MemberDeletionService memberDeletionService;
+
+
+    //  매일 새벽 3시 정각에 삭제 유예 기간이 지난 회원을 완전 삭제
+    @Scheduled(cron = "0 0 3 * * ?") // 매일 03:00 AM
+    public void cleanUpDeletedMembers() {
+        memberDeletionService.deleteOutdatedMembers();
+    }
+}

--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberDeletionService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberDeletionService.java
@@ -1,0 +1,63 @@
+package site.walkies.walkie.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.walkies.walkie.domain.character.service.CharacterService;
+import site.walkies.walkie.domain.egg.service.EggService;
+import site.walkies.walkie.domain.member.entity.Member;
+import site.walkies.walkie.domain.member.repository.MemberRepository;
+import site.walkies.walkie.domain.member.token.MemberRefreshTokenService;
+import site.walkies.walkie.domain.review.service.ReviewService;
+import site.walkies.walkie.global.web.exception.CustomException;
+import site.walkies.walkie.global.web.exception.ErrorCode;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MemberDeletionService {
+
+    // 여러 개의 서비스나 리포를 한꺼번에 의존성을 받아서 작업을 해야 하기 때문에, 기존 memberService와 분리했습니다.
+
+    private final MemberRepository memberRepository;
+    private final ReviewService reviewService;
+    private final EggService eggService;
+    private final CharacterService characterService;
+    private final MemberRefreshTokenService refreshTokenService;
+
+    // 회원 탈퇴 요청 시 (Soft Delete)
+    @Transactional
+    public Long softDeleteMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        member.markDeleted(LocalDateTime.now()); // deleteCd = true, deleteRequestedAt 설정
+        member.changeLevelingEgg(null);
+        member.changeLevelingUserCharacter(null);
+
+        reviewService.deleteReviewCodeByUserId(memberId);
+        refreshTokenService.deleteByMember(member);
+
+        return member.getId();
+    }
+
+    // 한 달 뒤 회원 완전 삭제 (스케줄러 또는 관리용 배치에서 호출)
+    @Transactional
+    public void deleteOutdatedMembers() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(30);
+        List<Member> members = memberRepository.findAllByDeleteCdTrueAndDeleteRequestedAtBefore(threshold);
+
+        for (Member member : members) {
+            Long memberId = member.getId();
+
+            reviewService.deleteReviewByUserId(memberId);
+            member.changeLevelingEgg(null);
+            member.changeLevelingUserCharacter(null);
+            eggService.deleteEggByUserId(memberId);
+            characterService.deleteEggByUserId(memberId);
+            memberRepository.delete(member);
+        }
+    }
+}

--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
@@ -69,6 +69,7 @@ public class MemberLoginService {
                 .memberTier("초보워키")
                 .levelingEgg(null)
                 .levelingUserCharacter(null)
+                .deleteCd(false)
                 .build();
 
         Member savedMember = memberRepository.save(newMember);

--- a/src/main/java/site/walkies/walkie/global/auth/filter/JwtFilter.java
+++ b/src/main/java/site/walkies/walkie/global/auth/filter/JwtFilter.java
@@ -80,6 +80,11 @@ public class JwtFilter extends GenericFilterBean {
 
                 Member member = memberLoginService.findMemberById(memberId);
 
+                if (Boolean.TRUE.equals(member.getDeleteCd())) {
+                    log.warn("[JwtFilter] 탈퇴 유저의 접근 차단: memberId={}, uri={}", member.getId(), requestURI);
+                    throw new CustomException(ErrorCode.DELETED_USER_CANNOT_ACCESS);
+                }
+
                 UserDetails userDetails = MemberPrincipal.createMemberAuthority(member);
                 UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                 SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/site/walkies/walkie/global/web/exception/ErrorCode.java
+++ b/src/main/java/site/walkies/walkie/global/web/exception/ErrorCode.java
@@ -14,6 +14,8 @@ public enum ErrorCode {
     //    INVALID_PASSWORD("올바르지 않은 비밀번호입니다.", HttpStatus.UNAUTHORIZED),
     INVALID_ACCESS_TOKEN("올바르지 않은 ACCESSTOKEN 입니다", HttpStatus.UNAUTHORIZED),
     //    JSON_PROCESSING_ERROR("JSON 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    DELETED_USER_CANNOT_LOGIN("탈퇴 유예 중인 유저는 로그인 할 수 없습니다. ", HttpStatus.UNAUTHORIZED),
+    DELETED_USER_CANNOT_ACCESS("탈퇴한 유저는 접근할 수 없습니다.", HttpStatus.UNAUTHORIZED),
 
     // 알 관련 예외
     EGG_NOT_FOUND("해당 id를 가진 알이 없습니다.", HttpStatus.NOT_FOUND),


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #131 

### 📝 작업 내용
- 유저 삭제 요청을 보내면, 회원과 리뷰에서 soft delete를 하고, 요청 시간을 기록해 둠
- 스케쥴러를 사용하여 매일 새벽 3시마다  삭제 요청이 온지 한 달이 지난 멤버들을 찾아서 데이터를 완전 삭제함

- 실행 화면(삭제 전)
    - ![image](https://github.com/user-attachments/assets/a8688f7e-d22e-41f5-a2be-352707903850)
    - Member의 deleteCd가 false이고, deleteRequestedAt이 null임
    - ![image](https://github.com/user-attachments/assets/da146388-ed58-4053-8864-a7532a3d4cdf)
    - 리뷰도 deleteCd false로 되어 있음

- 실행 화면(삭제 후) 
    - ![image](https://github.com/user-attachments/assets/ef8901a4-a634-4bf9-9e5d-b43eebf7d9e6)
    - 삭제 요청 성공
    - ![image](https://github.com/user-attachments/assets/b775ddac-cbf8-41c2-94d8-16f236cf7e1d)
    - Member의 deleteCd가 true로 바뀌고, deleteRequestedAt에 요청 시간이 들어감
    - ![image](https://github.com/user-attachments/assets/bb3a8778-a95b-4260-983a-c937af891869)
    - 리뷰도 deleteCd가 true로 바뀜.
    - ![image](https://github.com/user-attachments/assets/8d27061b-2d0e-4b43-a902-d3ea2884f96c)
    - 회원탈퇴한 후 요청 보내려 하면, 이렇게 나옴

### 🙏 리뷰 요구사항
- 
