### PR TITLE
Feat/#171 : JWT토큰 만료시간 운영 환경 기준으로 변경

### DIFF
--- a/src/main/java/site/walkies/walkie/global/auth/utils/JWTProvider.java
+++ b/src/main/java/site/walkies/walkie/global/auth/utils/JWTProvider.java
@@ -21,11 +21,11 @@ import java.util.Date;
 @Slf4j
 public class JWTProvider implements InitializingBean {
 
-    // Access Token 유효기간 (3분)
-    private static final long ACCESS_TOKEN_EXPIRATION_SECONDS = 180;
+    @Value("${jwt.access-token-expiration-seconds}")
+    private long accessTokenExpirationSeconds;
 
-    // Refresh Token 유효기간 (5분)
-    private static final long REFRESH_TOKEN_EXPIRATION_SECONDS = 300;
+    @Value("${jwt.refresh-token-expiration-seconds}")
+    private long refreshTokenExpirationSeconds;
 
     // JWT Claims 키 이름 정의
     private static final String PROVIDER_ID = "providerId";
@@ -53,13 +53,13 @@ public class JWTProvider implements InitializingBean {
     // Access Token 발급
     // 사용 위치: 로그인, 회원가입
     public String buildAccessToken(String providerId, Long memberId) {
-        return buildToken(providerId, memberId, ACCESS_TOKEN_EXPIRATION_SECONDS);
+        return buildToken(providerId, memberId, accessTokenExpirationSeconds);
     }
 
     // Refresh Token 발급
     // 사용 위치: 로그인, 회원가입
     public String buildRefreshToken(String providerId, Long memberId) {
-        return buildToken(providerId, memberId, REFRESH_TOKEN_EXPIRATION_SECONDS);
+        return buildToken(providerId, memberId, refreshTokenExpirationSeconds);
     }
 
     // 실제 JWT 생성 로직

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,3 +41,7 @@ server.tomcat.connection-timeout=10s
 # ?? ?? ??
 spring.servlet.multipart.max-file-size=20MB
 spring.servlet.multipart.max-request-size=100MB
+
+# JWT Token Expiration (? ??)
+jwt.access-token-expiration-seconds=7200
+jwt.refresh-token-expiration-seconds=2592000


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #171 

### 📝 작업 내용
- 기존 3분/5분이던 토큰의 만료시간을 각각 2시간/1달로 변경
- 그리고, 토큰의 만료시간은 운영 환경에 따라 변할 수 있는 것이므로, 설정 파일에 넣는 것이 더 적합하다고 판단되어서 클래스 내에서 상수 형태로 넣던 것을 `application.properties`안에 넣었습니다.
- 실행 화면
    - accessToken(2시간)
    - ![image](https://github.com/user-attachments/assets/b084b1dc-37c5-4c14-a182-eaa3fabc363e)
    - refreshToken(1달)
    - ![image](https://github.com/user-attachments/assets/93a55f94-36bc-4c2d-a14a-3954a4568151)

### 🙏 리뷰 요구사항
- 만료시간은 secret에 넣을 필요는 없다고 생각해서, secret은 따로 업데이트 하지 않으셔도 됩니다.
