### PR TITLE
Fix/#173 : 레벨업 중인 알이 null일 경우 NPE 발생하는 문제 수정

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
@@ -41,21 +41,23 @@ public class MemberService {
         }
         return convertMemberToResponseDto(member);
     }
-  
+
     // 사용자가 부화시키는 알 변경
     @Transactional
     public EggResponse updateMemberLevelingEgg(Long memberId, MemberUpdateLevelingEggRequestDto memberUpdateLevelingEggRequestDto){
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        Egg previousEgg = member.getLevelingEgg();
-        if (previousEgg != null) {
-            previousEgg.changePicked(false);
-        }
-
         Egg egg = eggRepository.findById(memberUpdateLevelingEggRequestDto.getEggId())
                 .orElseThrow(() -> new CustomException(ErrorCode.EGG_NOT_FOUND));
 
+        Egg previousEgg = member.getLevelingEgg();
+        // 부화시키는 알이 null인 경우나, 이전과 같은 알을 선택한 경우(프론트 오류 등으로 인해)는 체크 따로 안하기.
+        if (previousEgg != null && !previousEgg.getId().equals(egg.getId())) {
+            previousEgg.changePicked(false);
+        }
+
         member.changeLevelingEgg(egg);
         egg.changePicked(true);
+
 
         return EggResponse.builder()
                 .eggId(egg.getId())

--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
@@ -47,7 +47,9 @@ public class MemberService {
     public EggResponse updateMemberLevelingEgg(Long memberId, MemberUpdateLevelingEggRequestDto memberUpdateLevelingEggRequestDto){
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         Egg previousEgg = member.getLevelingEgg();
-        previousEgg.changePicked(false);
+        if (previousEgg != null) {
+            previousEgg.changePicked(false);
+        }
 
         Egg egg = eggRepository.findById(memberUpdateLevelingEggRequestDto.getEggId())
                 .orElseThrow(() -> new CustomException(ErrorCode.EGG_NOT_FOUND));


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #173 

### 📝 작업 내용
- 이전에 null일 경우에, 해당 알의 picked를 false로 하려다가 예외가 생긴 것이여서, null이 아닌 경우에만 해당 설정 하도록 함
- 실행 화면
- ![image](https://github.com/user-attachments/assets/682e972d-4678-4ec4-9282-09922c01508f)
- levelingEgg를 null로 해놓고, API를 호출했을 때 잘 동작함.


### 🙏 리뷰 요구사항
- 
