### PR TITLE
Fix/#184 : 탈퇴한 유저가 토큰이 필요없는 API에 접근할 때 예외처리 로직 수정 + 리뷰 조회 시 날짜가 아닌 id를 기준으로 정렬하도록 수정

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/member/repository/MemberRepository.java
+++ b/src/main/java/site/walkies/walkie/domain/member/repository/MemberRepository.java
@@ -16,4 +16,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     // 스케쥴러로 매일 삭제할 것들 탐색하기
     List<Member> findAllByDeleteCdTrueAndDeleteRequestedAtBefore(LocalDateTime before);
+
+    Optional<Member> findByProviderAndProviderId(String provider, String providerId);
 }

--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
@@ -12,6 +12,7 @@ import site.walkies.walkie.global.web.exception.ErrorCode;
 import site.walkies.walkie.global.webhook.DiscordNotifier;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -25,13 +26,23 @@ public class MemberLoginService {
     public MemberResponseDto findKakaoMember(KakaoUserInfoResponseDto userInfo) {
         String providerId = userInfo.getId().toString();
         return memberRepository.findByProviderId(providerId)
-                .map(this::convertMemberToMemberResponseDto)
+                .map(member -> {
+                    if (Boolean.TRUE.equals(member.getDeleteCd())) { // ✅ 수정됨
+                        throw new CustomException(ErrorCode.DELETED_USER_CANNOT_LOGIN);
+                    }
+                    return convertMemberToMemberResponseDto(member);
+                })
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 
     public MemberResponseDto findAppleMember(String appleUserId) {
         return memberRepository.findByProviderId(appleUserId)
-                .map(this::convertMemberToMemberResponseDto)
+                .map(member -> {
+                    if (Boolean.TRUE.equals(member.getDeleteCd())) { // ✅ 수정됨
+                        throw new CustomException(ErrorCode.DELETED_USER_CANNOT_LOGIN);
+                    }
+                    return convertMemberToMemberResponseDto(member);
+                })
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 
@@ -55,9 +66,13 @@ public class MemberLoginService {
     // 멤버 생성
     private MemberResponseDto createMember(String provider, String providerId, String nickname) {
         // 기존에 있는 회원인지 조회
-        boolean existsMember = memberRepository.existsByProviderAndProviderId(provider, providerId);
+        Optional<Member> existingOpt = memberRepository.findByProviderAndProviderId(provider, providerId); // ✅ 수정됨
 
-        if(existsMember) {
+        if (existingOpt.isPresent()) {
+            Member existing = existingOpt.get();
+            if (Boolean.TRUE.equals(existing.getDeleteCd())) {
+                throw new CustomException(ErrorCode.DELETED_USER_CANNOT_LOGIN); // ✅ 수정됨
+            }
             throw new CustomException(ErrorCode.ALREADY_REGISTERED_USER);
         }
 

--- a/src/main/java/site/walkies/walkie/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/site/walkies/walkie/domain/review/repository/ReviewRepository.java
@@ -19,8 +19,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     // 리뷰 갯수 조회
     int countBySpotId(Long spotId);
 
-    // 해당 스팟에 대한 모든 유저의 리뷰 날짜 내림차순 조회
-    List<Review> findBySpotIdAndDeleteCdFalseOrderByReviewDateDesc(Long spotId);
+    // 해당 스팟에 대한 모든 유저의 리뷰 id 내림차순 조회
+    List<Review> findBySpotIdAndDeleteCdFalseOrderByIdDesc(Long spotId);
 
     // 스팟에 대한 방문자 수 조회
     int countDistinctBySpotIdAndDeleteCdFalse(Long spotId);
@@ -34,6 +34,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     // 스팟에 대한 유저의 리뷰 개수 조회
     int countByMemberIdAndSpotIdAndDeleteCdFalse(Long memberId, Long spotId);
 
-    // 특정 멤버의 스팟에 대한 모든 리뷰 검색 후 날짜 내림차순 조회
-    List<Review> findByMemberIdAndSpotIdAndDeleteCdFalseOrderByReviewDateDesc(Long memberId, Long spotId);
+    // 특정 멤버의 스팟에 대한 모든 리뷰 검색 후 id 내림차순 조회
+    List<Review> findByMemberIdAndSpotIdAndDeleteCdFalseOrderByIdDesc(Long memberId, Long spotId);
 }

--- a/src/main/java/site/walkies/walkie/domain/review/service/ReviewService.java
+++ b/src/main/java/site/walkies/walkie/domain/review/service/ReviewService.java
@@ -140,7 +140,7 @@ public class ReviewService {
             throw new CustomException(ErrorCode.USER_NOT_FOUND);
         }
 
-        List<Review> reviews =  reviewRepository.findBySpotIdAndDeleteCdFalseOrderByReviewDateDesc(spotId);
+        List<Review> reviews =  reviewRepository.findBySpotIdAndDeleteCdFalseOrderByIdDesc(spotId);
 
         // 조회된 리뷰를 저장할 리스트 (키워드 추가)
         List<GetReviewResponse> responses = new ArrayList<>();

--- a/src/main/java/site/walkies/walkie/domain/spot/service/SpotService.java
+++ b/src/main/java/site/walkies/walkie/domain/spot/service/SpotService.java
@@ -106,7 +106,7 @@ public class SpotService {
     }
 
     private int getDaysUntilNextVisit(Long spotId, Long memberId) {
-        List<Review> reviews = reviewRepository.findByMemberIdAndSpotIdAndDeleteCdFalseOrderByReviewDateDesc(memberId, spotId);
+        List<Review> reviews = reviewRepository.findByMemberIdAndSpotIdAndDeleteCdFalseOrderByIdDesc(memberId, spotId);
 
         if (reviews.isEmpty()) return 0;
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #184 

### 📝 작업 내용
- 실행 화면
- 리뷰 조회 시 id 기준 정렬
- ![image](https://github.com/user-attachments/assets/0f27c36d-17a4-42d7-a61a-5ce08d1c9bd2)


### 🙏 리뷰 요구사항
- 
