### PR TITLE
Feat/#187 : 회원가입 시 기본 알 하나 주는 로직 추가

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/egg/service/EggService.java
+++ b/src/main/java/site/walkies/walkie/domain/egg/service/EggService.java
@@ -86,13 +86,13 @@ public class EggService {
 
         // 2. Egg 타입별 분기 처리 (각 알의 확률 값에 따라)
         if (eggRandom <= EggsProbability.NORMAL_EGG.getProbability()) {
-            egg =  processEgg(userId, obtainedPosition, obtainedDate, member, EggsProbability.NORMAL_EGG, characterRandom, characterClassRandom, 2000);
+            egg =  processEgg(obtainedPosition, obtainedDate, member, EggsProbability.NORMAL_EGG, characterRandom, characterClassRandom, 2000);
         } else if (eggRandom <= EggsProbability.RARE_EGG.getProbability()) {
-            egg =  processEgg(userId, obtainedPosition, obtainedDate, member, EggsProbability.RARE_EGG, characterRandom, characterClassRandom, 6000);
+            egg =  processEgg(obtainedPosition, obtainedDate, member, EggsProbability.RARE_EGG, characterRandom, characterClassRandom, 6000);
         } else if (eggRandom <= EggsProbability.EPIC_EGG.getProbability()) {
-            egg =  processEgg(userId, obtainedPosition, obtainedDate, member, EggsProbability.EPIC_EGG, characterRandom, characterClassRandom, 8000);
+            egg =  processEgg(obtainedPosition, obtainedDate, member, EggsProbability.EPIC_EGG, characterRandom, characterClassRandom, 8000);
         } else if (eggRandom <= EggsProbability.LEGENDARY_EGG.getProbability()) {
-            egg =  processEgg(userId, obtainedPosition, obtainedDate, member, EggsProbability.LEGENDARY_EGG, characterRandom, characterClassRandom, 10000);
+            egg =  processEgg(obtainedPosition, obtainedDate, member, EggsProbability.LEGENDARY_EGG, characterRandom, characterClassRandom, 10000);
         }
 
         EggResponse response = EggResponse.builder()
@@ -116,10 +116,12 @@ public class EggService {
     // 주어진 알의  캐릭터 확률을 기반으로 후보 배열을 선택하고 Egg를 생성하는 함수
     // input : userId, obtainedPosition(얻은 위치), obtainedDate(얻은 날짜), Member, eggProb(알의 등급), characterRandom(캐릭터 등급 랜덤 값), characterClassRandom(캐릭터 종류 랜덥값),eggWalk(필요 걸음수)
     // output : Egg
-    private Egg processEgg(long userId, String obtainedPosition, LocalDate obtainedDate, Member member,
+    public Egg processEgg(String obtainedPosition, LocalDate obtainedDate, Member member,
                            EggsProbability eggProb, double characterRandom, double characterClassRandom, int eggWalk) {
         // 캐릭터 종류 후보 배열
         CharacterProbability[] candidates;
+
+        long userId = member.getId();
 
         // characterRandom을 통해서 캐릭터 등급을 고르고, 각 등급의 캐릭터 종류 후보 배열 생성
         // 일반 등급

--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
@@ -4,9 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import site.walkies.walkie.domain.auth.service.dto.response.KakaoUserInfoResponseDto;
 import site.walkies.walkie.domain.character.service.CharacterService;
+import site.walkies.walkie.domain.egg.service.EggService;
 import site.walkies.walkie.domain.member.repository.MemberRepository;
 import site.walkies.walkie.domain.member.entity.Member;
 import site.walkies.walkie.domain.member.service.dto.response.MemberResponseDto;
+import site.walkies.walkie.global.probability.EggsProbability;
 import site.walkies.walkie.global.web.exception.CustomException;
 import site.walkies.walkie.global.web.exception.ErrorCode;
 import site.walkies.walkie.global.webhook.DiscordNotifier;
@@ -21,6 +23,7 @@ public class MemberLoginService {
     private final MemberRepository memberRepository;
     private final CharacterService characterService;
     private final DiscordNotifier discordNotifier;
+    private final EggService eggService;
 
     // 로그인 확인용 (회원 조회만)
     public MemberResponseDto findKakaoMember(KakaoUserInfoResponseDto userInfo) {
@@ -71,7 +74,7 @@ public class MemberLoginService {
         if (existingOpt.isPresent()) {
             Member existing = existingOpt.get();
             if (Boolean.TRUE.equals(existing.getDeleteCd())) {
-                throw new CustomException(ErrorCode.DELETED_USER_CANNOT_LOGIN); // ✅ 수정됨
+                throw new CustomException(ErrorCode.DELETED_USER_CANNOT_LOGIN);
             }
             throw new CustomException(ErrorCode.ALREADY_REGISTERED_USER);
         }
@@ -91,6 +94,7 @@ public class MemberLoginService {
 
         Member savedMember = memberRepository.save(newMember);
         newMember.changeLevelingUserCharacter(characterService.createDefaultCharacter(newMember.getId(), LocalDate.now()));
+        newMember.changeLevelingEgg(eggService.processEgg("탄생의 바다", LocalDate.now(), savedMember, EggsProbability.NORMAL_EGG, Math.random() * 100, Math.random() * 100, 0));
 
         // 디스코드 전송
         String errorLog = "**축!! 회원가입!!**\n"

--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
@@ -81,11 +81,14 @@ public class MemberService {
     public MemberResponseDto updateMemberLevelingCharacter(Long memberId, MemberUpdateCharacterRequestDto memberUpdateCharacterRequestDto){
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        UserCharacter previousCharacter = member.getLevelingUserCharacter();
-        previousCharacter.changePicked(false);
+        UserCharacter character = characterRepository.findById(memberUpdateCharacterRequestDto.getCharacterId())
+                .orElseThrow(() -> new CustomException(ErrorCode.CHARACTER_NOT_FOUND));
 
-        UserCharacter character = characterRepository.findById(memberUpdateCharacterRequestDto.getCharacterId()).orElseThrow(() -> new CustomException(ErrorCode.CHARACTER_NOT_FOUND));
-      
+        UserCharacter previousCharacter = member.getLevelingUserCharacter();
+        if(previousCharacter != null && !previousCharacter.getId().equals(character.getId())) {
+            previousCharacter.changePicked(false);
+        }
+
         member.changeLevelingUserCharacter(character);
         character.changePicked(true);
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #187 

### 📝 작업 내용
- 실행 화면
    -  API 호출
    - ![image](https://github.com/user-attachments/assets/eda6ff2b-26b9-4286-8702-666d47df03fb)
    - 만들어진 멤버 정보 확인
    - ![image](https://github.com/user-attachments/assets/cdccf544-5b7e-4895-9faf-2ff46e86de82)
    - 이전과는 달리, 알이 하나 추가된 걸 볼 수 있습니다.

### 🙏 리뷰 요구사항
- 이거 테스트하려고 준전설급 팬케이크 다이노 있던 계정 날려버렸습니다... 눈물의 리뷰 부탁드립니다...
