### PR TITLE
Feat/#196 : 사용자 행동 추적 및 에러 진단을 위한 로그 추가

### DIFF
--- a/src/main/java/site/walkies/walkie/WalkieApplication.java
+++ b/src/main/java/site/walkies/walkie/WalkieApplication.java
@@ -1,5 +1,6 @@
 package site.walkies.walkie;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
@@ -7,12 +8,14 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
 @SpringBootApplication()
+@Slf4j
 public class WalkieApplication {
 
 	public static void main(String[] args) {
 		System.out.println("HealthCheck started");
 		SpringApplication.run(WalkieApplication.class, args);
 		System.out.println("HealthCheck finished");
+		log.info("[Startup] Walkie 서버가 성공적으로 시작되었습니다.");
 	}
 
 }

--- a/src/main/java/site/walkies/walkie/domain/auth/service/AuthService.java
+++ b/src/main/java/site/walkies/walkie/domain/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package site.walkies.walkie.domain.auth.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import site.walkies.walkie.domain.auth.service.dto.request.AuthCheckRequestDto;
 import site.walkies.walkie.domain.auth.service.dto.request.AuthSignupRequestDto;
@@ -19,6 +20,7 @@ import site.walkies.walkie.global.web.exception.ErrorCode;
 import java.time.LocalDateTime;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class AuthService {
 
@@ -49,6 +51,8 @@ public class AuthService {
 
         // refreshToken 저장
         saveRefreshToken(memberResponseDto.getId(), refreshToken);
+
+        log.info("ID: {} 인 사용자가 로그인 했습니다.", memberResponseDto.getId());
 
         return LoginResponseDto.builder()
                 .provider(memberResponseDto.getProvider())
@@ -150,6 +154,9 @@ public class AuthService {
     public MemberResponseDto logout(Long memberId){
         Member member = memberLoginService.findMemberById(memberId);
         memberRefreshTokenService.deleteByMember(member);
+
+        log.info("ID: {} 인 사용자가 로그아웃 했습니다.", memberId);
+
         return MemberResponseDto.builder()
                 .id(member.getId())
                 .nickname(member.getNickname())

--- a/src/main/java/site/walkies/walkie/domain/egg/service/EggService.java
+++ b/src/main/java/site/walkies/walkie/domain/egg/service/EggService.java
@@ -1,12 +1,8 @@
 package site.walkies.walkie.domain.egg.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.http.*;
 import site.walkies.walkie.domain.character.entity.UserCharacter;
 import site.walkies.walkie.domain.character.repository.UserCharacterRepository;
 import site.walkies.walkie.domain.character.service.CharacterService;
@@ -26,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class EggService {
 
@@ -227,6 +224,7 @@ public class EggService {
     // output : GetEggCountResponse
     public GetEggCountResponse getEggCount(long userId) {
         GetEggCountResponse response = GetEggCountResponse.builder().eggCount(eggRepository.countAllByUserId(userId)).build();
+        log.info("ID: {}인 사용자가 자신의 알 {}개를 조회하였습니다.", userId, response.getEggCount());
         return response;
     }
 
@@ -251,6 +249,8 @@ public class EggService {
             Member member = memberRepository.findById(egg.getUser().getId()).orElse(null);
             member.changeLevelingEgg(null);
             memberRepository.save(member);
+
+            log.info("ID: {}인 사용자가 부화에 {}걸음이 필요한 {}번 알을 부화시켰습니다.", member.getId(), egg.getNeedStep(), egg.getId());
 
             eggRepository.delete(egg);
             EggResponse response = EggResponse.builder()

--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
@@ -1,6 +1,7 @@
 package site.walkies.walkie.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import site.walkies.walkie.domain.auth.service.dto.response.KakaoUserInfoResponseDto;
 import site.walkies.walkie.domain.character.service.CharacterService;
@@ -17,6 +18,7 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class MemberLoginService {
 
@@ -101,6 +103,8 @@ public class MemberLoginService {
                 + nickname + "님이" + memberRepository.count() + "번째 워키멤버가 되었습니다.";
 
         discordNotifier.sendRegistMessage(errorLog);
+
+        log.info("{} 를 통해 회원이 가입하였습니다. ", provider);
 
         return convertMemberToMemberResponseDto(savedMember);
     }

--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package site.walkies.walkie.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.walkies.walkie.domain.egg.entity.Egg;
@@ -19,6 +20,7 @@ import site.walkies.walkie.global.web.exception.CustomException;
 import site.walkies.walkie.global.web.exception.ErrorCode;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
@@ -142,6 +144,10 @@ public class MemberService {
     public MemberResponseDto toggleMemberProfileVisibility(Long memberId) {
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         member.changeProfileVisibility(!member.getIsPublic());
+
+        //로그 기록을 위한 공개 여부 문자열화
+        String memberVisibility = member.getIsPublic() ? "public" : "private";
+        log.info("ID: {} 인 사용자가 자신의 프로필 공개 여부를 {}로 전환하였습니다.", memberId, memberVisibility);
         return convertMemberToResponseDto(member);
     }
 

--- a/src/main/java/site/walkies/walkie/domain/review/service/ReviewService.java
+++ b/src/main/java/site/walkies/walkie/domain/review/service/ReviewService.java
@@ -72,6 +72,9 @@ public class ReviewService {
         //리뷰 저장
         reviewRepository.save(createReview);
 
+        log.info("ID: {} 인 사용자가 {}번 스팟({})에 대해 {} 점의 리뷰를 작성하였습니다.", member.getId(), spotId, spot.getLocationName(), rating);
+        log.info("ID: {} 인 사용자가 {}번 스팟({})에 대해 '{}' 라는 내용의 리뷰를 남겼습니다.", member.getId(), spotId, spot.getLocationName(), review);
+
         PostReviewResponse response = PostReviewResponse.builder()
                 .spotId(createReview.getSpot().getId())
                 .distance(createReview.getDistance())
@@ -189,6 +192,8 @@ public class ReviewService {
         patchReview.updateReviewCd(true).updateReviewText(review).updateRating(rating);
 
         Review patchedReview = reviewRepository.save(patchReview);
+
+        log.info("ID: {} 인 사용자가 {}번 스팟({})에 대해 '{}' 라는 내용의 리뷰로 업데이트했습니다.", memberId, patchedReview.getSpot().getId(), patchedReview.getSpot().getLocationName(), review);
 
         PatchReviewResponse response = PatchReviewResponse.builder()
                 .reviewId(patchedReview.getId())

--- a/src/main/java/site/walkies/walkie/domain/spot/service/SpotService.java
+++ b/src/main/java/site/walkies/walkie/domain/spot/service/SpotService.java
@@ -2,6 +2,7 @@ package site.walkies.walkie.domain.spot.service;
 
 import com.uber.h3core.H3Core;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.walkies.walkie.domain.review.entity.Review;
@@ -22,6 +23,7 @@ import java.util.List;
 
 @Service
 @Transactional
+@Slf4j
 @RequiredArgsConstructor
 public class SpotService {
 
@@ -48,6 +50,8 @@ public class SpotService {
 
         // 방문자 수 (distinct member 기준)
         int visitCount = reviewRepository.countDistinctBySpotIdAndDeleteCdFalse(spotId);
+
+        log.info("ID: {} 인 사용자가 {} 번 스팟 ({}) 의 정보를 조회했습니다.",  memberId, spotId, spot.getLocationName());
 
         // DTO 생성
         return SpotResponseDto.builder()
@@ -85,6 +89,8 @@ public class SpotService {
 
         // String h3FromRequest = h3Core.geoToH3Address(37.5639, 126.9873, 9);
         // System.out.println("명동성당 직접 계산한 H3: " + h3FromRequest);
+
+        log.info("ID: {} 인 사용자가 lat: {} , lng : {} 인 위치에서 {} 개의 스팟을 검색하였습니다.", memberId, request.getLatitude(), request.getLongitude(), nearbySpots.size() );
 
         return nearbySpots.stream()
                 .map(spot -> {

--- a/src/main/java/site/walkies/walkie/global/config/WebmvcConfig.java
+++ b/src/main/java/site/walkies/walkie/global/config/WebmvcConfig.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import site.walkies.walkie.global.logging.RequestLoggingInterceptor;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 
 @Configuration
 @RequiredArgsConstructor
@@ -16,5 +18,11 @@ public class WebmvcConfig implements WebMvcConfigurer {
                 .allowedMethods("GET", "POST", "PUT", "PATCH","DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .maxAge(3000);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new RequestLoggingInterceptor())
+                .addPathPatterns("/**"); // 모든 요청 로그 수집
     }
 }

--- a/src/main/java/site/walkies/walkie/global/logging/RequestLoggingInterceptor.java
+++ b/src/main/java/site/walkies/walkie/global/logging/RequestLoggingInterceptor.java
@@ -1,0 +1,16 @@
+package site.walkies.walkie.global.logging;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+public class RequestLoggingInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        log.info("[Request] {} {}", request.getMethod(), request.getRequestURI());
+        return true;
+    }
+}


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #196

### 📝 작업 내용
- 사용자 행동 추적을 위한 로그
    - 요청
        - 모든 요청에 대한 로그 인터셉터 추가 
    - 서비스(비즈니스) 로직 
        - 사용자 회원가입 / 로그인 / 로그아웃 / 프로필 공개 토글 변경
        - 알 개수 조회 / 부화시키기
        - 스팟 상세조회 / 주변 스팟 조회
        - 리뷰 작성 / 수정
- 에러 진단을 위한 로그
    - 서버의 재시동 부분에 추가한 로그
    - `ExceptionHandler`에 예외 상황이 날 때 보내는 로그(기존에 있었음)

### 🙏 리뷰 요구사항
- 현재 문서에 적힌 부분만 로그를 만들었습니다. 추후 운영하며 필요한 부분, 특히 에러 부분에 대한 세부적인 로그 처리가 필요하다고 생각합니다.
