### PR TITLE
Fix/#198: 회원가입 시 생성된 Egg가 Member의 levelingEgg 필드에 반영되지 않는 문제를 해결하기 위한 트랜잭션 처리 개선

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
@@ -1,5 +1,6 @@
 package site.walkies.walkie.domain.member.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import site.walkies.walkie.domain.auth.service.dto.response.KakaoUserInfoResponseDto;
@@ -67,7 +68,8 @@ public class MemberLoginService {
     }
 
     // 멤버 생성
-    private MemberResponseDto createMember(String provider, String providerId, String nickname) {
+    @Transactional
+    public MemberResponseDto createMember(String provider, String providerId, String nickname) {
         // 기존에 있는 회원인지 조회
         Optional<Member> existingOpt = memberRepository.findByProviderAndProviderId(provider, providerId); // ✅ 수정됨
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #198 

### 📝 작업 내용
- 회원가입 로직에 `@Transactional` 적용
- Member 저장 후 levelingEgg 필드 수정이 같은 트랜잭션 내에서 처리되도록 구조 정비
- 필요 시 `createMember()` 접근제어자 수정 (private → protected/public)

### 🙏 리뷰 요구사항
- 
