### PR TITLE
Refactor/#200 : 전략 패턴 적용하여 소셜 로그인 분기 로직 구조 개선

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/auth/service/AuthService.java
+++ b/src/main/java/site/walkies/walkie/domain/auth/service/AuthService.java
@@ -25,8 +25,6 @@ import java.util.stream.Collectors;
 @Slf4j
 public class AuthService {
 
-//    private final KakaoService kakaoService;
-//    private final AppleService appleService;
     private final MemberLoginService memberLoginService;
     private final JWTProvider jwtProvider;
     private final MemberRefreshTokenService memberRefreshTokenService;
@@ -89,19 +87,6 @@ public class AuthService {
                 requestDto.getNickname()
         );
 
-//        switch (requestDto.getProvider().toLowerCase()) {
-//            case "kakao":
-//                KakaoUserInfoResponseDto kakaoUserInfo = kakaoService.getUserInfo(requestDto.getLoginAccessToken());
-//                memberResponseDto = memberLoginService.createKakaoMember(kakaoUserInfo, requestDto.getNickname());
-//                break;
-//            case "apple":
-//                String appleUserId = appleService.getAppleUserIdFromToken(requestDto.getLoginAccessToken());
-//                memberResponseDto = memberLoginService.createAppleMember(appleUserId, requestDto.getNickname());
-//                break;
-//            default:
-//                throw new IllegalArgumentException("지원하지 않는 로그인 방식입니다.");
-//        }
-
         String accessToken = jwtProvider.buildAccessToken(memberResponseDto.getProviderId(), memberResponseDto.getId());
         String refreshToken = jwtProvider.buildRefreshToken(memberResponseDto.getProviderId(), memberResponseDto.getId());
 
@@ -121,28 +106,6 @@ public class AuthService {
 
         memberRefreshTokenService.saveOrUpdateToken(member, refreshToken, expiresAt);
     }
-
-    /*
-    private MemberResponseDto getExistingMemberIfExists(AuthCheckRequestDto requestDto) {
-        try {
-            switch (requestDto.getProvider().toLowerCase()) {
-                case "kakao":
-                    KakaoUserInfoResponseDto kakaoUserInfo = kakaoService.getUserInfo(requestDto.getLoginAccessToken());
-                    return memberLoginService.findKakaoMember(kakaoUserInfo);
-                case "apple":
-                    String appleUserId = appleService.getAppleUserIdFromToken(requestDto.getLoginAccessToken());
-                    return memberLoginService.findAppleMember(appleUserId);
-                default:
-                    throw new IllegalArgumentException("지원하지 않는 로그인 방식입니다.");
-            }
-        } catch (CustomException e) {
-            if (e.getErrorCode() == ErrorCode.USER_NOT_FOUND) {
-                return null;
-            }
-            throw e;
-        }
-    }
-     */
 
     // 리프레시 토큰 재발급
     public LoginResponseDto refreshAccessToken(RefreshTokenRequestDto requestDto) {

--- a/src/main/java/site/walkies/walkie/domain/auth/service/AuthService.java
+++ b/src/main/java/site/walkies/walkie/domain/auth/service/AuthService.java
@@ -1,13 +1,13 @@
 package site.walkies.walkie.domain.auth.service;
 
-import lombok.RequiredArgsConstructor;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import site.walkies.walkie.domain.auth.service.dto.request.AuthCheckRequestDto;
 import site.walkies.walkie.domain.auth.service.dto.request.AuthSignupRequestDto;
 import site.walkies.walkie.domain.auth.service.dto.request.RefreshTokenRequestDto;
-import site.walkies.walkie.domain.auth.service.dto.response.KakaoUserInfoResponseDto;
 import site.walkies.walkie.domain.auth.service.dto.response.LoginResponseDto;
+import site.walkies.walkie.domain.auth.strategy.SocialLoginStrategy;
 import site.walkies.walkie.domain.member.entity.Member;
 import site.walkies.walkie.domain.member.service.MemberLoginService;
 import site.walkies.walkie.domain.member.service.dto.response.MemberResponseDto;
@@ -18,35 +18,54 @@ import site.walkies.walkie.global.web.exception.CustomException;
 import site.walkies.walkie.global.web.exception.ErrorCode;
 
 import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
-@RequiredArgsConstructor
 public class AuthService {
 
-    private final KakaoService kakaoService;
-    private final AppleService appleService;
+//    private final KakaoService kakaoService;
+//    private final AppleService appleService;
     private final MemberLoginService memberLoginService;
     private final JWTProvider jwtProvider;
     private final MemberRefreshTokenService memberRefreshTokenService;
+    private final Map<String, SocialLoginStrategy> strategyMap;
 
+    // 전략 매핑을 위하여 `@RequiredArgsConstructor` 대신 생성자 주입 사용
+    public AuthService(
+            List<SocialLoginStrategy> strategies,
+            JWTProvider jwtProvider,
+            MemberRefreshTokenService memberRefreshTokenService,
+            MemberLoginService memberLoginService
+    ){
+        this.jwtProvider = jwtProvider;
+        this.memberRefreshTokenService = memberRefreshTokenService;
+        this.memberLoginService = memberLoginService;
+        this.strategyMap = strategies.stream().collect(Collectors.toMap(SocialLoginStrategy::getProviderName, s -> s));
+    }
+
+    // 사용자가 있다면 -> 로그인, 없다면 -> 회원가입 유도
     public LoginResponseDto checkUserExists(AuthCheckRequestDto requestDto) {
-        MemberResponseDto memberResponseDto = getExistingMemberIfExists(requestDto);
+        SocialLoginStrategy strategy = getStrategy(requestDto.getProvider());
 
-        if (memberResponseDto == null) {
-            // 회원이 없는 경우: 프론트에서 회원가입 유도
-            return LoginResponseDto.builder()
-                    .provider(requestDto.getProvider())
-                    .accessToken(null)
-                    .refreshToken(null)
-                    .build();
+        MemberResponseDto memberResponseDto;
+        try{
+            memberResponseDto = strategy.findMember(requestDto.getLoginAccessToken());
+        } catch (CustomException e) {
+            if(e.getErrorCode() == ErrorCode.USER_NOT_FOUND) {
+                // 회원이 없는 경우: 프론트에서 회원가입 유도
+                return LoginResponseDto.builder()
+                        .provider(requestDto.getProvider())
+                        .accessToken(null)
+                        .refreshToken(null)
+                        .build();
+            }
+            throw e;
         }
 
         // 토큰 발급
-        String accessToken = jwtProvider.buildAccessToken(
-                memberResponseDto.getProviderId(),
-                memberResponseDto.getId()
-        );
+        String accessToken = jwtProvider.buildAccessToken(memberResponseDto.getProviderId(), memberResponseDto.getId());
         String refreshToken = jwtProvider.buildRefreshToken(memberResponseDto.getProviderId(), memberResponseDto.getId());
 
         // refreshToken 저장
@@ -61,26 +80,29 @@ public class AuthService {
                 .build();
     }
 
+    // 사용자 회원가입
     public LoginResponseDto signupNewUser(AuthSignupRequestDto requestDto) {
-        MemberResponseDto memberResponseDto;
+        SocialLoginStrategy strategy = getStrategy(requestDto.getProvider());
 
-        switch (requestDto.getProvider().toLowerCase()) {
-            case "kakao":
-                KakaoUserInfoResponseDto kakaoUserInfo = kakaoService.getUserInfo(requestDto.getLoginAccessToken());
-                memberResponseDto = memberLoginService.createKakaoMember(kakaoUserInfo, requestDto.getNickname());
-                break;
-            case "apple":
-                String appleUserId = appleService.getAppleUserIdFromToken(requestDto.getLoginAccessToken());
-                memberResponseDto = memberLoginService.createAppleMember(appleUserId, requestDto.getNickname());
-                break;
-            default:
-                throw new IllegalArgumentException("지원하지 않는 로그인 방식입니다.");
-        }
-
-        String accessToken = jwtProvider.buildAccessToken(
-                memberResponseDto.getProviderId(),
-                memberResponseDto.getId()
+        MemberResponseDto memberResponseDto = strategy.signup(
+                requestDto.getLoginAccessToken(),
+                requestDto.getNickname()
         );
+
+//        switch (requestDto.getProvider().toLowerCase()) {
+//            case "kakao":
+//                KakaoUserInfoResponseDto kakaoUserInfo = kakaoService.getUserInfo(requestDto.getLoginAccessToken());
+//                memberResponseDto = memberLoginService.createKakaoMember(kakaoUserInfo, requestDto.getNickname());
+//                break;
+//            case "apple":
+//                String appleUserId = appleService.getAppleUserIdFromToken(requestDto.getLoginAccessToken());
+//                memberResponseDto = memberLoginService.createAppleMember(appleUserId, requestDto.getNickname());
+//                break;
+//            default:
+//                throw new IllegalArgumentException("지원하지 않는 로그인 방식입니다.");
+//        }
+
+        String accessToken = jwtProvider.buildAccessToken(memberResponseDto.getProviderId(), memberResponseDto.getId());
         String refreshToken = jwtProvider.buildRefreshToken(memberResponseDto.getProviderId(), memberResponseDto.getId());
 
         saveRefreshToken(memberResponseDto.getId(), refreshToken);
@@ -92,6 +114,7 @@ public class AuthService {
                 .build();
     }
 
+    // RefreshToken 저장
     private void saveRefreshToken(Long memberId, String refreshToken) {
         Member member = memberLoginService.findMemberById(memberId);
         LocalDateTime expiresAt = LocalDateTime.now().plusSeconds(300); // 5분짜리 토큰
@@ -99,6 +122,7 @@ public class AuthService {
         memberRefreshTokenService.saveOrUpdateToken(member, refreshToken, expiresAt);
     }
 
+    /*
     private MemberResponseDto getExistingMemberIfExists(AuthCheckRequestDto requestDto) {
         try {
             switch (requestDto.getProvider().toLowerCase()) {
@@ -118,7 +142,9 @@ public class AuthService {
             throw e;
         }
     }
+     */
 
+    // 리프레시 토큰 재발급
     public LoginResponseDto refreshAccessToken(RefreshTokenRequestDto requestDto) {
         String refreshToken = requestDto.getRefreshToken();
 
@@ -169,6 +195,15 @@ public class AuthService {
                 .memberTier(member.getMemberTier())
                 .isPublic(member.getIsPublic())
                 .build();
+    }
+
+    // provider에 알맞은 전략 조회
+    private SocialLoginStrategy getStrategy(String provider) {
+        SocialLoginStrategy strategy = strategyMap.get(provider.toLowerCase());
+        if (strategy == null) {
+            throw new IllegalArgumentException("지원하지 않는 로그인 방식입니다: " + provider);
+        }
+        return strategy;
     }
 
 }

--- a/src/main/java/site/walkies/walkie/domain/auth/strategy/AppleLoginStrategy.java
+++ b/src/main/java/site/walkies/walkie/domain/auth/strategy/AppleLoginStrategy.java
@@ -1,0 +1,35 @@
+package site.walkies.walkie.domain.auth.strategy;
+
+import org.springframework.stereotype.Component;
+import site.walkies.walkie.domain.auth.service.AppleService;
+import site.walkies.walkie.domain.member.service.MemberLoginService;
+import site.walkies.walkie.domain.member.service.dto.response.MemberResponseDto;
+
+@Component
+public class AppleLoginStrategy implements SocialLoginStrategy {
+
+    private final AppleService appleService;
+    private final MemberLoginService memberLoginService;
+
+    public AppleLoginStrategy(AppleService appleService, MemberLoginService memberLoginService) {
+        this.appleService = appleService;
+        this.memberLoginService = memberLoginService;
+    }
+
+    @Override
+    public String getProviderName() {
+        return "apple";
+    }
+
+    @Override
+    public MemberResponseDto findMember(String token) {
+        String appleUserId = appleService.getAppleUserIdFromToken(token);
+        return memberLoginService.findAppleMember(appleUserId);
+    }
+
+    @Override
+    public MemberResponseDto signup(String token, String nickname) {
+        String appleUserId = appleService.getAppleUserIdFromToken(token);
+        return memberLoginService.createAppleMember(appleUserId, nickname);
+    }
+}

--- a/src/main/java/site/walkies/walkie/domain/auth/strategy/KakaoLoginStrategy.java
+++ b/src/main/java/site/walkies/walkie/domain/auth/strategy/KakaoLoginStrategy.java
@@ -1,0 +1,36 @@
+package site.walkies.walkie.domain.auth.strategy;
+
+import org.springframework.stereotype.Component;
+import site.walkies.walkie.domain.auth.service.KakaoService;
+import site.walkies.walkie.domain.auth.service.dto.response.KakaoUserInfoResponseDto;
+import site.walkies.walkie.domain.member.service.MemberLoginService;
+import site.walkies.walkie.domain.member.service.dto.response.MemberResponseDto;
+
+@Component
+public class KakaoLoginStrategy implements SocialLoginStrategy {
+
+    private final KakaoService kakaoService;
+    private final MemberLoginService memberLoginService;
+
+    public KakaoLoginStrategy(KakaoService kakaoService, MemberLoginService memberLoginService) {
+        this.kakaoService = kakaoService;
+        this.memberLoginService = memberLoginService;
+    }
+
+    @Override
+    public String getProviderName() {
+        return "kakao";
+    }
+
+    @Override
+    public MemberResponseDto findMember(String token) {
+        KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo(token);
+        return memberLoginService.findKakaoMember(userInfo);
+    }
+
+    @Override
+    public MemberResponseDto signup(String token, String nickname) {
+        KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo(token);
+        return memberLoginService.createKakaoMember(userInfo, nickname);
+    }
+}

--- a/src/main/java/site/walkies/walkie/domain/auth/strategy/SocialLoginStrategy.java
+++ b/src/main/java/site/walkies/walkie/domain/auth/strategy/SocialLoginStrategy.java
@@ -1,0 +1,9 @@
+package site.walkies.walkie.domain.auth.strategy;
+
+import site.walkies.walkie.domain.member.service.dto.response.MemberResponseDto;
+
+public interface SocialLoginStrategy {
+    String getProviderName();
+    MemberResponseDto findMember(String token); // 기존 getExistingMemberIfExists를 대체
+    MemberResponseDto signup(String token, String nickname);
+}


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #200 

### 📝 작업 내용
- 기존 구조
    - ![image](https://github.com/user-attachments/assets/c779d7a9-f0d4-41ea-bc1b-4e4c662f2722)
     - `AuthService`가 모든 provider 로직에 직접 의존 -> 강한 결합
     - provider가 하나 추가될 때마다 AuthService 코드 수정 필요 -> 실수가 생길 수 있음
     - 단일 책임 원칙(SRP), 개방-폐쇄 원칙(OCP) 위반

- 개선된 구조
     - ![image](https://github.com/user-attachments/assets/a80b4549-e9ff-4792-92d9-8ad9b5e879c7)
     - `AuthService`는 구체 클래스가 아닌 인터페이스에만 의존 (DIP 준수)
     - 각 전략이 내부적으로 `KakaoService`, `AppleService`에 의존하므로 **책임 분리**
     - 새 로그인 방식이 추가되어도 기존 서비스 코드는 변경되지 않음 (OCP 준수)

- 테스트 화면
    - 카카오 로그인/회원여부체크 테스트
    - ![image](https://github.com/user-attachments/assets/1bfbede6-3ff3-474c-b1ee-f3fd1ca3baa7)
    - 카카오 회원가입 테스트
    - ![image](https://github.com/user-attachments/assets/75ac3b35-2aaf-44d2-a322-1ffc7dcf17bf)
    - 애플 로그인/회원여부체크 테스트
    - ![image](https://github.com/user-attachments/assets/30b054fc-86a5-42f0-963c-f24f95cdeb06)
    - 애플 회원가입 테스트
    - ![image](https://github.com/user-attachments/assets/37df550c-e9d2-432b-b2d0-a7726bbe12b2)


### 🙏 리뷰 요구사항
- 새로운 로그인 방식(naver, google)이 들어올 경우, 전략 추가만으로 대응 가능한 구조인지 확인 부탁드립니다.
- AuthService의 책임이 더 명확해졌는지, 구조적으로 괜찮은지 피드백 부탁드립니다.
- Walkie 만들면서 꼭 해보고 싶던 작업이였는데, 200번째 이슈로 작업하게 되어서 영광입니다... :)