### PR TITLE
Feat: FCM(Firebase Cloud Messaging) 연동 및 테스트용 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### key ###
 /src/main/resources/application-key.properties
+/src/main/resources/firebase/firebase-service-key.json

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 	implementation 'io.github.bonigarcia:webdrivermanager:5.4.0'
 	implementation 'org.jsoup:jsoup:1.20.1'
 
-	// build.gradle
+	// firebase-admin
 	implementation 'com.google.firebase:firebase-admin:9.5.0'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 	implementation 'org.seleniumhq.selenium:selenium-java:4.31.0'
 	implementation 'io.github.bonigarcia:webdrivermanager:5.4.0'
 	implementation 'org.jsoup:jsoup:1.20.1'
+
+	// build.gradle
+	implementation 'com.google.firebase:firebase-admin:9.5.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/site/walkies/walkie/domain/notification/controller/FcmController.java
+++ b/src/main/java/site/walkies/walkie/domain/notification/controller/FcmController.java
@@ -1,0 +1,51 @@
+package site.walkies.walkie.domain.notification.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import site.walkies.walkie.domain.notification.service.FcmService;
+import site.walkies.walkie.domain.notification.service.dto.request.FcmSendRequestDto;
+import site.walkies.walkie.global.web.dto.response.SuccessResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/fcm")
+public class FcmController {
+
+    private final FcmService fcmService;
+
+    @Operation(
+            summary = "FCM 테스트 메시지 전송",
+            description = """
+            Firebase Cloud Messaging(FCM)을 통해 알림 메시지를 디바이스에 전송합니다.  
+            이 API는 **안드로이드 또는 iOS에서 발급받은 디바이스 토큰을 입력받아**, 해당 기기로 테스트용 알림을 전송합니다.
+            """,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = FcmSendRequestDto.class),
+                            examples = @ExampleObject(name = "FCM 요청 예시", value = """
+                                {
+                                  "token": "your_device_fcm_token_here",
+                                  "title": "백엔드 테스트 알림",
+                                  "body": "FCM 연동 성공했는지 확인해주세요 🙌"
+                                }
+                            """)
+                    )
+            ),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "FCM 테스트 메시지 전송 완료"),
+                    @ApiResponse(responseCode = "500", description = "FCM 메시지 전송에 실패했습니다.")
+            }
+    )
+    @PostMapping("/test")
+    public SuccessResponse<String> sendTestNotification(@RequestBody FcmSendRequestDto requestDto) {
+        fcmService.sendNotification(requestDto);
+        return SuccessResponse.ok("FCM 테스트 메시지 전송 완료");
+    }
+}

--- a/src/main/java/site/walkies/walkie/domain/notification/service/FcmService.java
+++ b/src/main/java/site/walkies/walkie/domain/notification/service/FcmService.java
@@ -1,0 +1,40 @@
+package site.walkies.walkie.domain.notification.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.walkies.walkie.domain.notification.service.dto.request.FcmSendRequestDto;
+import site.walkies.walkie.global.web.exception.CustomException;
+import site.walkies.walkie.global.web.exception.ErrorCode;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class FcmService {
+
+    private static final String TEST_TOKEN = "클라이언트 개발자에게 받은 디바이스 토큰을 여기에";
+
+    @Transactional(readOnly = true)
+    public void sendNotification(FcmSendRequestDto requestDto) {
+        Message message = Message.builder()
+                .setToken(requestDto.getToken())
+                .setNotification(Notification.builder()
+                        .setTitle(requestDto.getTitle())
+                        .setBody(requestDto.getBody())
+                        .build())
+                .build();
+
+        try {
+            String response = FirebaseMessaging.getInstance().send(message);
+            log.info("FCM 메시지 전송 성공: {}", response);
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM 메시지 전송 실패", e);
+            throw new CustomException(ErrorCode.FCM_SEND_FAILED);
+        }
+    }
+}

--- a/src/main/java/site/walkies/walkie/domain/notification/service/dto/request/FcmSendRequestDto.java
+++ b/src/main/java/site/walkies/walkie/domain/notification/service/dto/request/FcmSendRequestDto.java
@@ -1,0 +1,10 @@
+package site.walkies.walkie.domain.notification.service.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class FcmSendRequestDto {
+    private String token;
+    private String title;
+    private String body;
+}

--- a/src/main/java/site/walkies/walkie/global/config/FirebaseConfig.java
+++ b/src/main/java/site/walkies/walkie/global/config/FirebaseConfig.java
@@ -1,0 +1,33 @@
+package site.walkies.walkie.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    @PostConstruct
+    public void init() {
+        try {
+            FileInputStream serviceAccount =
+                new FileInputStream("src/main/resources/firebase/firebase-service-key.json");
+
+            FirebaseOptions options = new FirebaseOptions.Builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
+
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+            }
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/site/walkies/walkie/global/web/exception/ErrorCode.java
+++ b/src/main/java/site/walkies/walkie/global/web/exception/ErrorCode.java
@@ -35,6 +35,9 @@ public enum ErrorCode {
     PARSING_ERROR("json 형식을 확인해주세요. 파싱에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     REVIEW_NOT_USER("해당 리뷰의 작성자가 아니므로, 변경 불가능합니다.", HttpStatus.NOT_ACCEPTABLE),
 
+    // FCM 관련 예외
+    FCM_SEND_FAILED("FCM 메시지 전송에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+
     // 스팟 관련 예외
     // 아래는 예시입니다. Enum이므로 마지막 예외에는 세미콜론 (;), 그 외에는 콤마(,)를 붙여줘야 합니다.
     SPOT_NOT_FOUND("해당 id를 가진 스팟이 없습니다.", HttpStatus.NOT_FOUND);


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #212 

### ✅ 진행 사항
- 테스트 화면
- <img width="647" height="510" alt="image" src="https://github.com/user-attachments/assets/35695229-efb0-41e3-a6a9-14297c9b2eec" />
- 진짜 토큰은 안드나 아요에서 보내야 하기 때문에, 백엔드 자체적으로는 이정도만 테스트할 수 있습니다.
- 해당 테스트가 실패로 나왔다는 것에서, Firebase 연동이 되었다고 할 수 있습니다.


### 📌 참고 사항
- Firebase Json 키를 저에게 따로 요청하세요.