### PR TITLE
Hotfix/#222 : FCM 토큰 검증 로직 추가

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/notification/controller/FcmController.java
+++ b/src/main/java/site/walkies/walkie/domain/notification/controller/FcmController.java
@@ -3,7 +3,9 @@ package site.walkies.walkie.domain.notification.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import site.walkies.walkie.domain.notification.service.FcmService;
 import site.walkies.walkie.domain.notification.service.dto.request.FcmSendRequestDto;
@@ -26,8 +28,8 @@ public class FcmController {
             @ApiResponse(responseCode = "200", description = "FCM 테스트 메시지 전송 완료"),
             @ApiResponse(responseCode = "500", description = "FCM 메시지 전송에 실패했습니다.")
     })
-    @PostMapping("/test")
-    public SuccessResponse<String> sendTestNotification(@RequestBody FcmSendRequestDto requestDto) {
+    @PostMapping(value="/test", consumes= MediaType.APPLICATION_JSON_VALUE)
+    public SuccessResponse<String> sendTestNotification(@Valid @RequestBody FcmSendRequestDto requestDto) {
         fcmService.sendNotification(requestDto);
         return SuccessResponse.ok("FCM 테스트 메시지 전송 완료");
     }

--- a/src/main/java/site/walkies/walkie/domain/notification/service/FcmService.java
+++ b/src/main/java/site/walkies/walkie/domain/notification/service/FcmService.java
@@ -21,6 +21,8 @@ public class FcmService {
 
     @Transactional(readOnly = true)
     public void sendNotification(FcmSendRequestDto requestDto) {
+        if(requestDto.getToken() == null || requestDto.getToken().isEmpty())
+            throw new CustomException(ErrorCode.FCM_TOKEN_VALUE_REQUIRED);
         Message message = Message.builder()
                 .setToken(requestDto.getToken())
                 .setNotification(Notification.builder()

--- a/src/main/java/site/walkies/walkie/domain/notification/service/dto/request/FcmSendRequestDto.java
+++ b/src/main/java/site/walkies/walkie/domain/notification/service/dto/request/FcmSendRequestDto.java
@@ -1,9 +1,15 @@
 package site.walkies.walkie.domain.notification.service.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class FcmSendRequestDto {
+    @NotBlank(message = "FCM 토큰은 필수입니다.")
     private String token;
     private String title;
     private String body;

--- a/src/main/java/site/walkies/walkie/global/web/exception/ErrorCode.java
+++ b/src/main/java/site/walkies/walkie/global/web/exception/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
     REVIEW_NOT_USER("해당 리뷰의 작성자가 아니므로, 변경 불가능합니다.", HttpStatus.NOT_ACCEPTABLE),
 
     // FCM 관련 예외
+    FCM_TOKEN_VALUE_REQUIRED("FCM 토큰을 필수로 넣어야 합니다.", HttpStatus.UNAUTHORIZED),
     FCM_SEND_FAILED("FCM 메시지 전송에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // 스팟 관련 예외


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #222 

### 📝 작업 내용
-  이제 토큰을 못받으면 401 에러 던짐
<img width="1373" height="652" alt="image" src="https://github.com/user-attachments/assets/6cf0b33d-6d33-45b0-adf2-ffc062aaf0cc" />


### 🙏 리뷰 요구사항
- 
