### PR TITLE
Feat/#237 : 회원가입 시 회원가입 날짜 저장 필드 + 로직 추가

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/member/entity/Member.java
+++ b/src/main/java/site/walkies/walkie/domain/member/entity/Member.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import site.walkies.walkie.domain.character.entity.UserCharacter;
 import site.walkies.walkie.domain.egg.entity.Egg;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -49,6 +50,9 @@ public class Member {
     @JoinColumn(name = "leveling_character_id")
     private UserCharacter levelingUserCharacter;
 
+    @Column(name = "joined_at")
+    private LocalDate joinedAt;
+
     @Column(name = "delete_cd")
     private Boolean deleteCd;
 
@@ -56,7 +60,7 @@ public class Member {
     private LocalDateTime deleteRequestedAt;
 
     @Builder
-    public Member(Long id, String providerId, String provider, String nickname, Integer exploredSpot, Integer recordedSpot, Boolean isPublic, String memberTier, Egg levelingEgg, UserCharacter levelingUserCharacter, Boolean deleteCd) {
+    public Member(Long id, String providerId, String provider, String nickname, Integer exploredSpot, Integer recordedSpot, Boolean isPublic, String memberTier, Egg levelingEgg, UserCharacter levelingUserCharacter, LocalDate joinedAt, Boolean deleteCd) {
         this.id = id;
         this.providerId = providerId;
         this.provider = provider;
@@ -66,6 +70,7 @@ public class Member {
         this.isPublic = isPublic;
         this.memberTier = memberTier;
         this.levelingEgg = levelingEgg;
+        this.joinedAt = joinedAt;
         this.levelingUserCharacter = levelingUserCharacter;
         this.deleteCd = deleteCd;
     }

--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberLoginService.java
@@ -94,6 +94,7 @@ public class MemberLoginService {
                 .memberTier("초보워키")
                 .levelingEgg(null)
                 .levelingUserCharacter(null)
+                .joinedAt(LocalDate.now())
                 .deleteCd(false)
                 .build();
 

--- a/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/MemberService.java
@@ -164,6 +164,7 @@ public class MemberService {
                 .userCharacterId(member.getLevelingUserCharacter() != null ? member.getLevelingUserCharacter().getId() : null)
                 .recordedSpot(member.getRecordedSpot())
                 .exploredSpot(member.getExploredSpot())
+                .joinedAt(member.getJoinedAt())
                 .build();
     }
 

--- a/src/main/java/site/walkies/walkie/domain/member/service/dto/response/MemberResponseDto.java
+++ b/src/main/java/site/walkies/walkie/domain/member/service/dto/response/MemberResponseDto.java
@@ -4,6 +4,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 @NoArgsConstructor
 @Getter
 public class MemberResponseDto {
@@ -17,9 +19,10 @@ public class MemberResponseDto {
     private String memberTier;
     private Long eggId;
     private Long userCharacterId;
+    private LocalDate joinedAt;
 
     @Builder
-    public MemberResponseDto(Long id, String providerId, String provider, String nickname, Integer exploredSpot, Integer recordedSpot, Boolean isPublic, String memberTier, Long eggId, Long userCharacterId) {
+    public MemberResponseDto(Long id, String providerId, String provider, String nickname, Integer exploredSpot, Integer recordedSpot, Boolean isPublic, String memberTier, Long eggId, Long userCharacterId, LocalDate joinedAt) {
         this.id = id;
         this.providerId = providerId;
         this.provider = provider;
@@ -30,5 +33,6 @@ public class MemberResponseDto {
         this.memberTier = memberTier;
         this.eggId = eggId;
         this.userCharacterId = userCharacterId;
+        this.joinedAt = joinedAt;
     }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #237 

### 📝 작업 내용
- Member 엔티티에 회원가입 날짜 저장하는 `joinedAt` 필드 추가, 생성자 수정
- 회원가입 API 내에 `joinedAt` 값 오늘 (`LocalDate.now()`) 설정 로직 추가

### 🙏 리뷰 요구사항
- 추가적인 작업(로직 수정 등) 필요하면 요청 바랍니다
