### PR TITLE
Fix/#245 : walkie.site로 주소 이전에 필요한 설정 값 및 url 리턴 값 변경

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/character/service/CharacterService.java
+++ b/src/main/java/site/walkies/walkie/domain/character/service/CharacterService.java
@@ -187,7 +187,7 @@ public class CharacterService {
                 .type(userCharacter.getType())
                 .characterName(cp.getName())
                 .characterDescription(cp.getDetail())
-                .characterImageUrl("https://truthguard.site/api/v1/file/" + cp.getPicUrl() + ".png")
+                .characterImageUrl("https://walkie.site/api/v1/file/" + cp.getPicUrl() + ".png")
                 .obtainedDetails(details)
                 .build();
         return response;

--- a/src/main/java/site/walkies/walkie/domain/health/service/HealthService.java
+++ b/src/main/java/site/walkies/walkie/domain/health/service/HealthService.java
@@ -85,7 +85,7 @@ public class HealthService {
                 .nowCalories(calories)
                 .caloriesName(targetCal.getFoodName())
                 .caloriesDescription(targetCal.getFoodDescription())
-                .caloriesUrl("https://truthguard.site/api/v1/file/" + targetCal.getImageUrl() + ".png")
+                .caloriesUrl("https://walkie.site/api/v1/file/" + targetCal.getImageUrl() + ".png")
                 .award(award)
                 .build();
     }

--- a/src/main/java/site/walkies/walkie/global/config/SecurityConfig.java
+++ b/src/main/java/site/walkies/walkie/global/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("https://truthguard.site", "http://localhost:5173", "https://walkie-virid.vercel.app", "https://walkie-frontend.vercel.app")); // 프론트 주소 명확히!
+        config.setAllowedOrigins(List.of("https://truthguard.site","https://walkie.site", "http://localhost:5173", "https://walkie-virid.vercel.app", "https://walkie-frontend.vercel.app")); // 프론트 주소 명확히!
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true); // withCredentials 요청 허용


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #245 

### 📝 작업 내용
- cors 설정 값 변경
- 리턴 url 변경
<img width="1428" height="305" alt="image" src="https://github.com/user-attachments/assets/66fe6e6b-94df-4ef7-add2-bd7ee44210c3" />
- walkie.site url로 접속시 사진 잘 나옴
<img width="1910" height="975" alt="image" src="https://github.com/user-attachments/assets/21bef73f-b719-4489-b148-cf93910ba930" />


### 🙏 리뷰 요구사항
- truthguard.site 주소가 곧 만료된다고 메일이 와서 주소 이전 작업 진행 했습니다.
- 2025.10.24 이후 DB url walkie.site로 변경하셔야 합니다.
