### PR TITLE
Fix/#248: GET /health response ENUM으로 변경

### DIFF
--- a/src/main/java/site/walkies/walkie/domain/health/enums/RewardPayoutStatus.java
+++ b/src/main/java/site/walkies/walkie/domain/health/enums/RewardPayoutStatus.java
@@ -1,0 +1,7 @@
+package site.walkies.walkie.domain.health.enums;
+
+public enum RewardPayoutStatus {
+    PENDING,     // 보류
+    AVAILABLE,   // 지급 가능
+    RECEIVED     // 지급 완료
+}

--- a/src/main/java/site/walkies/walkie/domain/health/service/HealthService.java
+++ b/src/main/java/site/walkies/walkie/domain/health/service/HealthService.java
@@ -9,6 +9,7 @@ import site.walkies.walkie.domain.egg.repository.HealthAwardRecordRepository;
 import site.walkies.walkie.domain.health.entity.HealthCurrent;
 import site.walkies.walkie.domain.health.entity.HealthHistory;
 import site.walkies.walkie.domain.health.enums.Calorie;
+import site.walkies.walkie.domain.health.enums.RewardPayoutStatus;
 import site.walkies.walkie.domain.health.repository.HealthCurrentRepository;
 import site.walkies.walkie.domain.health.repository.HealthHistoryRepository;
 import site.walkies.walkie.domain.health.service.dto.response.*;
@@ -42,7 +43,8 @@ public class HealthService {
         // 상세 조회 검색 (current DB)
         HealthCurrent healthCurrent = healthCurrentRepository.findByMemberIdAndNowDay(memberId,searchDate).orElse(null);
 
-        boolean award = false;
+        // 기록이 없는 경우 => 목표 달성 X + 안받은 것과 동일 => PENDING
+        RewardPayoutStatus award = RewardPayoutStatus.PENDING;
 
         if(healthCurrent != null) {
             award = awardReceivedCheck(healthCurrent.getNowSteps(), healthCurrent.getTargetSteps(), memberId, searchDate);
@@ -75,7 +77,7 @@ public class HealthService {
     }
 
     // response 생성 method
-    private HealthDetailResponseDto healthDetailResponseDtoBuilder(int targetSteps, int steps, double distance, double calories,boolean award) {
+    private HealthDetailResponseDto healthDetailResponseDtoBuilder(int targetSteps, int steps, double distance, double calories, RewardPayoutStatus award) {
         Calorie targetCal = calculateCalories(calories);
 
         return HealthDetailResponseDto.builder()
@@ -134,7 +136,8 @@ public class HealthService {
             // current에서 조회
             HealthCurrent healthCurrent = healthCurrentRepository.findByMemberIdAndNowDay(memberId,tempDate).orElse(null);
 
-            boolean award = false;
+            // 기록이 없는 경우 => 목표 달성 X + 안받은 것과 동일 => PENDING
+            RewardPayoutStatus award = RewardPayoutStatus.PENDING;
 
             if(healthCurrent != null) {
                 award = awardReceivedCheck(healthCurrent.getNowSteps(), healthCurrent.getTargetSteps(), memberId, tempDate);
@@ -304,17 +307,22 @@ public class HealthService {
     }
 
     // 보상을 받았는지 판단하는 함수
-    private boolean awardReceivedCheck(int nowSteps, int targetSteps,long memberId, LocalDate searchDate) {
-        // 목표를 달성한 경우
-        if(nowSteps >= targetSteps) {
-            // 보상을 받았는지 조회
-            HealthAwardRecord healthAwardRecord = healthAwardRecordRepository.findByMemberIdAndReceivedDate(memberId, searchDate).orElse(null);
-            // 받지 않은 경우 + 회원가입일 보다 이후인 경우
-            Member member = memberRepository.findById(memberId).orElse(null);
-            if(healthAwardRecord == null && !member.getJoinedAt().isAfter(searchDate)) {
-                return true;
+    private RewardPayoutStatus awardReceivedCheck(int nowSteps, int targetSteps,long memberId, LocalDate searchDate) {
+        // 보상을 받았는지 조회
+        HealthAwardRecord healthAwardRecord = healthAwardRecordRepository.findByMemberIdAndReceivedDate(memberId, searchDate).orElse(null);
+        // 받지 않은 경우 + 회원가입일 보다 이후인 경우
+        Member member = memberRepository.findById(memberId).orElse(null);
+        if(healthAwardRecord == null && !member.getJoinedAt().isAfter(searchDate)) {
+            // 오늘 날짜가 아니고, 목표를 달성한 경우
+            if(!searchDate.isEqual(LocalDate.now()) && nowSteps >= targetSteps) {
+                // 목표 달성 + 아직 안받은 경우
+                return RewardPayoutStatus.AVAILABLE;
+            } else {
+                // 목표 달성 X + 아직 안받은 경우 (오늘날짜인 경우 목표 달성 여부와 상관 없이 안받았으면 PENDING)
+                return RewardPayoutStatus.PENDING;
             }
         }
-        return false;
+        // 목표 달성 여부와 상관 없이 받은 경우
+        return RewardPayoutStatus.RECEIVED;
     }
 }

--- a/src/main/java/site/walkies/walkie/domain/health/service/dto/response/HealthDetailResponseDto.java
+++ b/src/main/java/site/walkies/walkie/domain/health/service/dto/response/HealthDetailResponseDto.java
@@ -2,6 +2,7 @@ package site.walkies.walkie.domain.health.service.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
+import site.walkies.walkie.domain.health.enums.RewardPayoutStatus;
 import site.walkies.walkie.domain.member.entity.Member;
 
 @Getter
@@ -14,5 +15,5 @@ public class HealthDetailResponseDto {
     private String caloriesName;
     private String caloriesDescription;
     private String caloriesUrl;
-    private Boolean award;
+    private RewardPayoutStatus award;
 }

--- a/src/main/java/site/walkies/walkie/domain/health/service/dto/response/HealthResponseDto.java
+++ b/src/main/java/site/walkies/walkie/domain/health/service/dto/response/HealthResponseDto.java
@@ -3,6 +3,7 @@ package site.walkies.walkie.domain.health.service.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
+import site.walkies.walkie.domain.health.enums.RewardPayoutStatus;
 
 import java.time.LocalDate;
 
@@ -13,5 +14,5 @@ public class HealthResponseDto {
     private LocalDate responseDate;
     private Integer targetSteps;
     private Integer nowSteps;
-    private Boolean award;
+    private RewardPayoutStatus award;
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #248 

### 📝 작업 내용
- GET /health response ENUM으로 변경
목표 걸음수 달성 + Received -> Received
목표 걸음수 달성 + pending -> available
목표 걸음수 미달성 + pending -> pending
목표 걸음수 미달성 + received -> received
<img width="1322" height="447" alt="image" src="https://github.com/user-attachments/assets/9db66e23-b68b-47f4-afc8-d4adb8933c59" />
- 오늘 날짜의 경우 목표 달성 시에도 available이 아닌 pending
<img width="1043" height="87" alt="image" src="https://github.com/user-attachments/assets/54cc2a36-315e-4efb-b263-111d3730109e" />

### 🙏 리뷰 요구사항
- X
